### PR TITLE
Validations

### DIFF
--- a/packages/ng-openapi/src/lib/generators/service/service-method/service-method-params.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/service/service-method/service-method-params.generator.ts
@@ -1,5 +1,6 @@
 import { OptionalKind, ParameterDeclarationStructure } from "ts-morph";
-import { camelCase, GeneratorConfig, getTypeScriptType, PathInfo } from "@ng-openapi/shared";
+import { camelCase, GeneratorConfig, getTypeScriptType, isDataTypeInterface, PathInfo } from "@ng-openapi/shared";
+import { generateParseRequestTypeParams } from "@ng-openapi/shared";
 
 export class ServiceMethodParamsGenerator {
     private config: GeneratorConfig;
@@ -10,7 +11,7 @@ export class ServiceMethodParamsGenerator {
 
     generateMethodParameters(operation: PathInfo): OptionalKind<ParameterDeclarationStructure>[] {
         const params = this.generateApiParameters(operation);
-        const optionsParam = this.addOptionsParameter();
+        const optionsParam = this.addOptionsParameter(params);
 
         // Combine all parameters
         const combined = [...params, ...optionsParam];
@@ -58,7 +59,7 @@ export class ServiceMethodParamsGenerator {
         // body parameters
         if (operation.requestBody && operation.requestBody?.content?.["application/json"]) {
             const bodyType = this.getRequestBodyType(operation.requestBody);
-            const isInterface = this.isDataTypeInterface(bodyType);
+            const isInterface = isDataTypeInterface(bodyType);
             params.push({
                 name: isInterface ? camelCase(bodyType) : "requestBody",
                 type: bodyType,
@@ -79,7 +80,7 @@ export class ServiceMethodParamsGenerator {
         return params.sort((a, b) => Number(a.hasQuestionToken) - Number(b.hasQuestionToken));
     }
 
-    addOptionsParameter(): OptionalKind<ParameterDeclarationStructure>[] {
+    addOptionsParameter(params: OptionalKind<ParameterDeclarationStructure>[]): OptionalKind<ParameterDeclarationStructure>[] {
         return [
             {
                 name: "observe",
@@ -88,15 +89,28 @@ export class ServiceMethodParamsGenerator {
             },
             {
                 name: "options",
-                type: `{ headers?: HttpHeaders; params?: HttpParams; reportProgress?: boolean; responseType?: 'arraybuffer' | 'blob' | 'json' | 'text'; withCredentials?: boolean; context?: HttpContext; }`,
+                type: this.getHttpRequestOptionsParameter(params),
                 hasQuestionToken: true,
             },
         ];
     }
 
-    isDataTypeInterface(type: string): boolean {
-        const invalidTypes = ["any", "File", "string", "number", "boolean", "object", "unknown", "[]", "Array"];
-        return !invalidTypes.some((invalidType) => type.includes(invalidType));
+    private getHttpRequestOptionsParameter(params: OptionalKind<ParameterDeclarationStructure>[]): string {
+        const { response, request } = this.config.options.validation ?? {};
+        const parseRequest = request ? generateParseRequestTypeParams(params) : "";
+
+        const additionalTypeParameters = [];
+        if (response) {
+            additionalTypeParameters.push("any");
+        }
+        if (request && parseRequest) {
+            additionalTypeParameters.push(parseRequest);
+        }
+
+        if (additionalTypeParameters.length === 0) {
+            return `RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text'>`;
+        }
+        return `RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text', ${additionalTypeParameters.join(", ")}>`;
     }
 
     private getRequestBodyType(requestBody: any): string {

--- a/packages/ng-openapi/src/lib/generators/service/service.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/service/service.generator.ts
@@ -132,7 +132,7 @@ export class ServiceGenerator {
                 moduleSpecifier: "@angular/common/http",
             },
             {
-                namedImports: ["Observable"],
+                namedImports: ["Observable", "map"],
                 moduleSpecifier: "rxjs",
             },
             {

--- a/packages/ng-openapi/src/lib/generators/type/type.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/type/type.generator.ts
@@ -52,6 +52,8 @@ export class TypeGenerator {
                 this.generateInterface(name, definition);
             });
 
+            this.generateSdkTypes();
+
             this.sourceFile.formatText();
             this.sourceFile.saveSync();
         } catch (error) {
@@ -393,5 +395,80 @@ export class TypeGenerator {
 
     private escapeString(str: string): string {
         return str.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+    }
+
+    private generateSdkTypes() {
+        this.sourceFile.addImportDeclarations([
+            {
+                namedImports: ["HttpContext", "HttpHeaders"],
+                moduleSpecifier: "@angular/common/http",
+            },
+        ]);
+        const { response, request } = this.config.options.validation ?? {};
+        const typeParameters = [
+            "TResponseType extends 'arraybuffer' | 'blob' | 'json' | 'text'"
+        ];
+        const properties = [
+            {
+                name: "headers",
+                type: "HttpHeaders",
+                hasQuestionToken: true,
+            },
+            {
+                name: "reportProgress",
+                type: "boolean",
+                hasQuestionToken: true,
+            },
+            {
+                name: "responseType",
+                type: "TResponseType",
+                hasQuestionToken: true,
+            },
+            {
+                name: "withCredentials",
+                type: "boolean",
+                hasQuestionToken: true,
+            },
+            {
+                name: "context",
+                type: "HttpContext",
+                hasQuestionToken: true,
+            },
+        ];
+
+        if (response) {
+            properties.push({
+                name: "parse",
+                type: "(response: unknown) => TReturnType",
+                hasQuestionToken: true,
+            });
+            typeParameters.push("TReturnType");
+
+            const _typeParameters = [...typeParameters, "TParamsObject = never"];
+            this.sourceFile.addInterface({
+                name: "RequestOptions",
+                isExported: true,
+                typeParameters: _typeParameters,
+                properties: properties,
+                docs: ["Request Options for Angular HttpClient requests without request parsing"],
+            });
+        }
+
+        if (request) {
+            properties.push({
+                name: "parseRequest",
+                type: "(params: TParamsObject) => void",
+                hasQuestionToken: true,
+            });
+            typeParameters.push("TParamsObject");
+        }
+
+        this.sourceFile.addInterface({
+            name: "RequestOptions",
+            isExported: true,
+            typeParameters: typeParameters,
+            properties: properties,
+            docs: ["Request Options for Angular HttpClient requests"],
+        });
     }
 }

--- a/packages/shared/src/types/config.types.ts
+++ b/packages/shared/src/types/config.types.ts
@@ -11,6 +11,10 @@ export interface GeneratorConfig {
     options: {
         dateType: "string" | "Date";
         enumStyle: "enum" | "union";
+        validation?: {
+            response?: boolean;
+            request?: boolean;
+        };
         generateServices?: boolean;
         generateEnumBasedOnDescription?: boolean;
         customHeaders?: Record<string, string>;

--- a/packages/shared/src/utils/functions/collect-used-types.ts
+++ b/packages/shared/src/utils/functions/collect-used-types.ts
@@ -3,6 +3,7 @@ import { pascalCase } from "../index";
 
 export function collectUsedTypes(operations: PathInfo[]): Set<string> {
     const usedTypes = new Set<string>();
+    usedTypes.add("RequestOptions");
 
     operations.forEach((operation) => {
         // Check parameters

--- a/packages/shared/src/utils/functions/generate-parse-request-type-params.ts
+++ b/packages/shared/src/utils/functions/generate-parse-request-type-params.ts
@@ -1,0 +1,14 @@
+import { OptionalKind, ParameterDeclarationStructure } from "ts-morph";
+import { isDataTypeInterface } from "./is-data-type-interface";
+
+export function generateParseRequestTypeParams(params: OptionalKind<ParameterDeclarationStructure>[]): string {
+    const bodyParam = params.find(param => {
+        return typeof param.type === "string" && isDataTypeInterface(param.type)
+    });
+
+    if (bodyParam) {
+        const optional = bodyParam.hasQuestionToken ? " | undefined" : "";
+        return `${bodyParam.type}${optional}`;
+    }
+    return "";
+}

--- a/packages/shared/src/utils/functions/get-request-body-type.ts
+++ b/packages/shared/src/utils/functions/get-request-body-type.ts
@@ -1,0 +1,13 @@
+import { GeneratorConfig, RequestBody } from "../../types";
+import { getTypeScriptType } from "../type.utils";
+
+export function getRequestBodyType(requestBody: RequestBody, config: GeneratorConfig): string {
+    const content = requestBody.content || {};
+    const jsonContent = content["application/json"];
+
+    if (jsonContent?.schema) {
+        return getTypeScriptType(jsonContent.schema, config, jsonContent.schema.nullable);
+    }
+
+    return "any";
+}

--- a/packages/shared/src/utils/functions/index.ts
+++ b/packages/shared/src/utils/functions/index.ts
@@ -3,3 +3,6 @@ export * from "./token-names";
 export * from "./duplicate-function-name";
 export * from "./extract-paths";
 export * from "./extract-swagger-response-type";
+export * from "./get-request-body-type";
+export * from "./is-data-type-interface"
+export * from "./generate-parse-request-type-params"

--- a/packages/shared/src/utils/functions/is-data-type-interface.ts
+++ b/packages/shared/src/utils/functions/is-data-type-interface.ts
@@ -1,0 +1,4 @@
+export function isDataTypeInterface(type: string): boolean {
+    const invalidTypes = ["any", "File", "string", "number", "boolean", "object", "unknown", "[]", "Array"];
+    return !invalidTypes.some((invalidType) => type.includes(invalidType));
+}


### PR DESCRIPTION
This allows the user to implement a validation method `parse` & `parseRequest`,
These methods allow to use schema validation such as zod, valibot ...etc.

Response validations would apply to all requests.
Request validations is available for the request body only.

Closes #15 