### PR TITLE
fix: Add key if array value

### DIFF
--- a/packages/ng-openapi/src/lib/generators/utility/http-params-builder.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/utility/http-params-builder.generator.ts
@@ -44,7 +44,8 @@ export class HttpParamsBuilderGenerator {
                 returnType: "HttpParams",
                 docs: ["Adds a value to HttpParams. Delegates to recursive handler for objects/arrays."],
                 statements: `const isDate = value instanceof Date;
-const isObject = typeof value === "object" && !isDate;
+const isArray = Array.isArray(value);
+const isObject = typeof value === "object" && !isDate && !isArray;
 
 if (isObject) {
     return this.addToHttpParamsRecursive(httpParams, value);


### PR DESCRIPTION
If the value is an object (i.e. a signal) the key is not passed to addToHttpParamsRecursive, which leads in the case of a primitive to the error "key may not be null if value is primitive".