### PR TITLE
fix: prefer text encoding over blob for text types

### DIFF
--- a/packages/shared/src/utils/functions/extract-swagger-response-type.ts
+++ b/packages/shared/src/utils/functions/extract-swagger-response-type.ts
@@ -34,18 +34,10 @@ export function getResponseTypeFromResponse(
             continue;
         }
 
-        // Check schema format for binary indication
-        if (schema?.format === "binary" || schema?.format === "byte") {
-            responseTypes.push({
-                type: "blob",
-                priority: 2,
-                contentType,
-            });
-            continue;
-        }
+        const inferredType = inferResponseTypeFromContentType(contentType);
 
-        // Check if schema type indicates binary
-        if (schema?.type === "string" && (schema?.format === "binary" || schema?.format === "byte")) {
+        // Check schema format for binary indication
+        if (inferredType !== "text" && (schema?.format === "binary" || schema?.format === "byte")) {
             responseTypes.push({
                 type: "blob",
                 priority: 2,
@@ -56,7 +48,6 @@ export function getResponseTypeFromResponse(
 
         // Check if this is a primitive type in JSON format
         const isPrimitive = isPrimitiveType(schema);
-        const inferredType = inferResponseTypeFromContentType(contentType);
 
         let priority = 3; // default priority
         let finalType = inferredType;


### PR DESCRIPTION
Our API returns xml files and the openapi generator correctly sets the format to `bytes` as it sends a bytearray. But in JavaScript we don't actually want this as a blob, actually, the HttpClient of angular throws an error if we receive an `application/xml` when setting  `responseType` to `blob`.

This change forces any inferred `text` type to stay as `text`. 