### PR TITLE
feat(generator): emit functional interceptors for standalone apps

### DIFF
--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -9,13 +9,14 @@ The `provideNgOpenapi` function sets up the OpenAPI client in your Angular appli
 ## Usage
 
 ```typescript
-import { provideNgOpenapi } from "ng-openapi";
-import { provideHttpClient } from "@angular/common/http";
+import { provideNgOpenapi } from "./client/providers";
+import { provideHttpClient, withInterceptors } from "@angular/common/http";
 import { ApplicationConfig } from "@angular/core";
+import { defaultBaseInterceptor } from "./client/utils/base-interceptor";
 
 export const appConfig: ApplicationConfig = {
     providers: [
-        provideHttpClient(),
+        provideHttpClient(withInterceptors([defaultBaseInterceptor])),
         provideNgOpenapi({
             basePath: "https://api.example.com",
         }),
@@ -33,11 +34,13 @@ The base URL for your API. This is prepended to all API requests.
 
 ### `interceptors`
 
-**Type:** `HttpInterceptor[]` | **Default:** `[]`
+**Type:** `HttpInterceptor` classes | **Default:** `[]`
 
 Apply client specific interceptors. This is not going to replace the global interceptors configured in your application, but will be applied to requests made by the provided client.
 
 Interceptors can be re-used across different clients.
+
+The generated scoped interceptor is also available as a class for DI-based registration. Standalone applications should prefer the generated functional interceptor with `withInterceptors([...])`; DI-based setups can use `withInterceptorsFromDi()`.
 
 ### `enableDateTransform`
 

--- a/docs/api/utilities/date-transformer.md
+++ b/docs/api/utilities/date-transformer.md
@@ -14,29 +14,37 @@ The interceptor will be applied automatically to your HTTP client, if you are us
 
 ### Manual Setup
 
-If you chose to configure the OpenAPI client [manually](../providers.md#manual-configuration) or want to add the Date Transformer interceptor separately, you can do so by applying the `DateInterceptor` to your HTTP client in your `app.config.ts`.
+If you chose to configure the OpenAPI client [manually](../providers.md#manual-configuration) or want to add the Date Transformer interceptor separately, you can do so by applying the functional `dateInterceptor` to your HTTP client in your `app.config.ts`.
 
 ```typescript
 import { ApplicationConfig } from "@angular/core";
 import { provideHttpClient, withInterceptors } from "@angular/common/http";
-import { DateInterceptor } from "./client/utils/date-transformer";
+import { dateInterceptor } from "./client/utils/date-transformer";
 
 export const appConfig: ApplicationConfig = {
     providers: [
-        provideHttpClient(withInterceptors([DateInterceptor])),
+        provideHttpClient(withInterceptors([dateInterceptor])),
         { provide: BASE_PATH, useValue: "https://api.example.com" },
     ],
 };
 ```
 
+The generated `DateInterceptor` class is still exported for class-based registration with `HTTP_INTERCEPTORS` and `withInterceptorsFromDi()`.
+
 ## Example Date Transformer
 
 ```typescript
 // client/utils/date-transformer.ts
-import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } from "@angular/common/http";
+import {
+    HttpEvent,
+    HttpHandler,
+    HttpInterceptor,
+    HttpInterceptorFn,
+    HttpRequest,
+    HttpResponse,
+} from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { Observable } from "rxjs";
-import { map } from "rxjs/operators";
+import { Observable, map } from "rxjs";
 
 export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z?$/;
 
@@ -69,17 +77,19 @@ export function transformDates(obj: any): any {
     return obj;
 }
 
+function transformDateResponse(event: HttpEvent<any>): HttpEvent<any> {
+    if (event instanceof HttpResponse && event.body) {
+        return event.clone({ body: transformDates(event.body) });
+    }
+    return event;
+}
+
+export const dateInterceptor: HttpInterceptorFn = (req, next) => next(req).pipe(map(transformDateResponse));
+
 @Injectable()
 export class DateInterceptor implements HttpInterceptor {
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        return next.handle(req).pipe(
-            map((event) => {
-                if (event instanceof HttpResponse && event.body) {
-                    return event.clone({ body: transformDates(event.body) });
-                }
-                return event;
-            }),
-        );
+        return next.handle(req).pipe(map(transformDateResponse));
     }
 }
 ```

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -52,12 +52,13 @@ Add the provider to your `app.config.ts`:
 
 ```typescript
 import { ApplicationConfig } from "@angular/core";
-import { provideHttpClient } from "@angular/common/http";
+import { provideHttpClient, withInterceptors } from "@angular/common/http";
 import { provideNgOpenapi } from "./api/providers";
+import { defaultBaseInterceptor } from "./api/utils/base-interceptor";
 
 export const appConfig: ApplicationConfig = {
     providers: [
-        provideHttpClient(),
+        provideHttpClient(withInterceptors([defaultBaseInterceptor])),
         provideNgOpenapi({
             basePath: "https://api.example.com",
         }),

--- a/docs/guide/angular-integration.md
+++ b/docs/guide/angular-integration.md
@@ -12,12 +12,13 @@ Configure ng-openapi providers and services in your Angular application.
 
 ```typescript
 import { ApplicationConfig } from "@angular/core";
-import { provideHttpClient } from "@angular/common/http";
+import { provideHttpClient, withInterceptors } from "@angular/common/http";
 import { provideNgOpenapi } from "./client/providers";
+import { defaultBaseInterceptor } from "./client/utils/base-interceptor";
 
 export const appConfig: ApplicationConfig = {
     providers: [
-        provideHttpClient(),
+        provideHttpClient(withInterceptors([defaultBaseInterceptor])),
         provideNgOpenapi({
             basePath: "https://api.example.com",
         }),

--- a/docs/guide/date-handling.md
+++ b/docs/guide/date-handling.md
@@ -102,10 +102,10 @@ provideNgOpenapi({
 
 ```typescript
 import { provideHttpClient, withInterceptors } from "@angular/common/http";
-import { DateInterceptor } from "./client/utils/date-transformer";
+import { dateInterceptor } from "./client/utils/date-transformer";
 
 export const appConfig: ApplicationConfig = {
-    providers: [provideHttpClient(withInterceptors([DateInterceptor]))],
+    providers: [provideHttpClient(withInterceptors([dateInterceptor]))],
 };
 ```
 

--- a/docs/guide/multiple-clients.md
+++ b/docs/guide/multiple-clients.md
@@ -62,13 +62,15 @@ Each client generates its own provider function based on the `clientName`:
 ```typescript
 // app.config.ts
 import { ApplicationConfig } from "@angular/core";
-import { provideHttpClient } from "@angular/common/http";
+import { provideHttpClient, withInterceptors } from "@angular/common/http";
 import { provideUsersClient } from "./api/users/providers";
 import { provideOrdersClient } from "./api/orders/providers";
+import { usersBaseInterceptor } from "./api/users/utils/base-interceptor";
+import { ordersBaseInterceptor } from "./api/orders/utils/base-interceptor";
 
 export const appConfig: ApplicationConfig = {
     providers: [
-        provideHttpClient(),
+        provideHttpClient(withInterceptors([usersBaseInterceptor, ordersBaseInterceptor])),
         provideUsersClient({
             basePath: "https://users-api.example.com",
         }),
@@ -118,7 +120,7 @@ Configure interceptors per client:
 ```typescript
 export const appConfig: ApplicationConfig = {
     providers: [
-        provideHttpClient(),
+        provideHttpClient(withInterceptors([usersBaseInterceptor, ordersBaseInterceptor])),
         provideUsersClient({
             basePath: "https://users-api.example.com",
             interceptors: [AuthInterceptor], // Only for users API

--- a/packages/ng-openapi/README.md
+++ b/packages/ng-openapi/README.md
@@ -142,11 +142,13 @@ The simplest way to integrate ng-openapi is using the provider function:
 ```typescript
 // In your app.config.ts
 import { ApplicationConfig } from "@angular/core";
+import { provideHttpClient, withInterceptors } from "@angular/common/http";
 import { provideNgOpenapi } from "./api/providers";
+import { defaultBaseInterceptor } from "./api/utils/base-interceptor";
 
 export const appConfig: ApplicationConfig = {
     providers: [
-        // One-line setup with automatic interceptor configuration
+        provideHttpClient(withInterceptors([defaultBaseInterceptor])),
         provideNgOpenapi({
             basePath: "https://api.example.com",
         }),

--- a/packages/ng-openapi/src/lib/generators/utility/base-interceptor.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/utility/base-interceptor.generator.ts
@@ -1,4 +1,4 @@
-import { Project, Scope } from "ts-morph";
+import { Project, Scope, VariableDeclarationKind } from "ts-morph";
 import * as path from "path";
 import {
     BASE_INTERCEPTOR_HEADER_COMMENT,
@@ -25,10 +25,18 @@ export class BaseInterceptorGenerator {
 
         const interceptorsTokenName = getInterceptorsTokenName(this.#clientName);
         const clientContextTokenName = getClientContextTokenName(this.#clientName);
+        const baseInterceptorFunctionName = `${this.lowercaseFirst(this.#clientName)}BaseInterceptor`;
 
         sourceFile.addImportDeclarations([
             {
-                namedImports: ["HttpContextToken", "HttpEvent", "HttpHandler", "HttpInterceptor", "HttpRequest"],
+                namedImports: [
+                    "HttpContextToken",
+                    "HttpEvent",
+                    "HttpHandler",
+                    "HttpInterceptor",
+                    "HttpInterceptorFn",
+                    "HttpRequest",
+                ],
                 moduleSpecifier: "@angular/common/http",
             },
             {
@@ -44,6 +52,50 @@ export class BaseInterceptorGenerator {
                 moduleSpecifier: "../tokens",
             },
         ]);
+
+        sourceFile.addFunction({
+            name: "interceptClientRequest",
+            parameters: [
+                { name: "req", type: "HttpRequest<any>" },
+                { name: "next", type: "HttpHandler" },
+                { name: "httpInterceptors", type: "HttpInterceptor[]" },
+                { name: "clientContextToken", type: "HttpContextToken<string>" },
+            ],
+            returnType: "Observable<HttpEvent<any>>",
+            statements: `
+    // Check if this request belongs to this client using HttpContext
+    if (!req.context.has(clientContextToken)) {
+      // This request doesn't belong to this client, pass it through
+      return next.handle(req);
+    }
+
+    // Apply client-specific interceptors in reverse order
+    const handler = httpInterceptors.reduceRight(
+      (next, interceptor) => ({
+        handle: (request: HttpRequest<any>) => interceptor.intercept(request, next)
+      }),
+      next
+    );
+
+    return handler.handle(req);`,
+        });
+
+        sourceFile.addVariableStatement({
+            isExported: true,
+            declarationKind: VariableDeclarationKind.Const,
+            declarations: [
+                {
+                    name: baseInterceptorFunctionName,
+                    type: "HttpInterceptorFn",
+                    initializer: `(req, next) => interceptClientRequest(
+  req,
+  { handle: next },
+  inject(${interceptorsTokenName}),
+  ${clientContextTokenName}
+)`,
+                },
+            ],
+        });
 
         sourceFile.addClass({
             name: `${this.capitalizeFirst(this.#clientName)}BaseInterceptor`,
@@ -80,23 +132,7 @@ export class BaseInterceptorGenerator {
                     ],
                     returnType: "Observable<HttpEvent<any>>",
                     statements: `
-    // Check if this request belongs to this client using HttpContext
-    if (!req.context.has(this.clientContextToken)) {
-      // This request doesn't belong to this client, pass it through
-      return next.handle(req);
-    }
-
-    // Apply client-specific interceptors in reverse order
-    let handler = next;
-
-    handler = this.httpInterceptors.reduceRight(
-      (next, interceptor) => ({
-        handle: (request: HttpRequest<any>) => interceptor.intercept(request, next)
-      }),
-      handler
-    );
-
-    return handler.handle(req);`,
+    return interceptClientRequest(req, next, this.httpInterceptors, this.clientContextToken);`,
                 },
             ],
         });
@@ -107,5 +143,9 @@ export class BaseInterceptorGenerator {
 
     private capitalizeFirst(str: string): string {
         return str.charAt(0).toUpperCase() + str.slice(1);
+    }
+
+    private lowercaseFirst(str: string): string {
+        return str.charAt(0).toLowerCase() + str.slice(1);
     }
 }

--- a/packages/ng-openapi/src/lib/generators/utility/date-transformer.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/utility/date-transformer.generator.ts
@@ -16,7 +16,14 @@ export class DateTransformerGenerator {
 
         sourceFile.addImportDeclarations([
             {
-                namedImports: ["HttpEvent", "HttpHandler", "HttpInterceptor", "HttpRequest", "HttpResponse"],
+                namedImports: [
+                    "HttpEvent",
+                    "HttpHandler",
+                    "HttpInterceptor",
+                    "HttpInterceptorFn",
+                    "HttpRequest",
+                    "HttpResponse",
+                ],
                 moduleSpecifier: "@angular/common/http",
             },
             {
@@ -76,6 +83,29 @@ export class DateTransformerGenerator {
     return obj;`,
         });
 
+        sourceFile.addFunction({
+            name: "transformDateResponse",
+            parameters: [{ name: "event", type: "HttpEvent<any>" }],
+            returnType: "HttpEvent<any>",
+            statements: `
+    if (event instanceof HttpResponse && event.body) {
+        return event.clone({ body: transformDates(event.body) });
+    }
+    return event;`,
+        });
+
+        sourceFile.addVariableStatement({
+            isExported: true,
+            declarationKind: VariableDeclarationKind.Const,
+            declarations: [
+                {
+                    name: "dateInterceptor",
+                    type: "HttpInterceptorFn",
+                    initializer: `(req, next) => next(req).pipe(map(transformDateResponse))`,
+                },
+            ],
+        });
+
         // Add interceptor class
         sourceFile.addClass({
             name: "DateInterceptor",
@@ -96,14 +126,7 @@ export class DateTransformerGenerator {
                     ],
                     returnType: "Observable<HttpEvent<any>>",
                     statements: `
-    return next.handle(req).pipe(
-        map(event => {
-            if (event instanceof HttpResponse && event.body) {
-                return event.clone({ body: transformDates(event.body) });
-            }
-            return event;
-        })
-    );`,
+    return next.handle(req).pipe(map(transformDateResponse));`,
                 },
             ],
         });

--- a/packages/ng-openapi/src/lib/generators/utility/provider.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/utility/provider.generator.ts
@@ -27,6 +27,7 @@ export class ProviderGenerator {
         const basePathTokenName = getBasePathTokenName(this.clientName);
         const interceptorsTokenName = getInterceptorsTokenName(this.clientName);
         const baseInterceptorClassName = `${this.capitalizeFirst(this.clientName)}BaseInterceptor`;
+        const baseInterceptorFunctionName = `${this.lowercaseFirst(this.clientName)}BaseInterceptor`;
 
         // Add imports
         sourceFile.addImportDeclarations([
@@ -83,7 +84,13 @@ export class ProviderGenerator {
         });
 
         // Add main provider function
-        this.addMainProviderFunction(sourceFile, basePathTokenName, interceptorsTokenName, baseInterceptorClassName);
+        this.addMainProviderFunction(
+            sourceFile,
+            basePathTokenName,
+            interceptorsTokenName,
+            baseInterceptorClassName,
+            baseInterceptorFunctionName,
+        );
 
         sourceFile.formatText();
         sourceFile.saveSync();
@@ -94,6 +101,7 @@ export class ProviderGenerator {
         basePathTokenName: string,
         interceptorsTokenName: string,
         baseInterceptorClassName: string,
+        baseInterceptorFunctionName: string,
     ): void {
         const hasDateInterceptor = this.config.options.dateType === "Date";
         const functionName = `provide${this.capitalizeFirst(this.clientName)}Client`;
@@ -160,10 +168,13 @@ return makeEnvironmentProviders(providers);`;
                 "@example",
                 "```typescript",
                 "// In your app.config.ts",
+                "import { provideHttpClient, withInterceptors } from '@angular/common/http';",
                 `import { ${functionName} } from './api/providers';`,
+                `import { ${baseInterceptorFunctionName} } from './api/utils/base-interceptor';`,
                 "",
                 "export const appConfig: ApplicationConfig = {",
                 "  providers: [",
+                `    provideHttpClient(withInterceptors([${baseInterceptorFunctionName}])),`,
                 `    ${functionName}({`,
                 "      basePath: 'https://api.example.com',",
                 "      interceptors: [AuthInterceptor, LoggingInterceptor] // Classes, not instances",
@@ -206,5 +217,9 @@ return makeEnvironmentProviders(providers);`;
 
     private capitalizeFirst(str: string): string {
         return str.charAt(0).toUpperCase() + str.slice(1);
+    }
+
+    private lowercaseFirst(str: string): string {
+        return str.charAt(0).toLowerCase() + str.slice(1);
     }
 }


### PR DESCRIPTION
## Summary

- Closes #81.
- Emits `HttpInterceptorFn` exports for generated date and per-client scoped interceptors so standalone apps can use `provideHttpClient(withInterceptors([...]))`.
- Keeps the existing class-based `HttpInterceptor` implementations for DI-based compatibility and existing consumers.

## How to verify

- Run `npm run build:ng-openapi`.
- Generate a client with `dateType: "Date"` and verify `utils/date-transformer.ts` exports `dateInterceptor: HttpInterceptorFn`.
- Verify `utils/base-interceptor.ts` exports a functional scoped interceptor, for example `defaultBaseInterceptor`, while still exporting the existing class interceptor.

## Checklist

- [x] PR title follows Conventional Commits (see comment above)
- [x] Updated docs under `docs/` if user-facing behavior changed
- [x] Tested locally against a representative OpenAPI spec

## Generated output changes

Transformers now exports a functional interceptor and reuses the same response transformation logic from the class interceptor. Here an example of the Date transformer:

```ts
function transformDateResponse(event: HttpEvent<any>): HttpEvent<any> {
  if (event instanceof HttpResponse && event.body) {
    return event.clone({ body: transformDates(event.body) });
  }
  return event;
}

export const dateInterceptor: HttpInterceptorFn = (req, next) =>
  next(req).pipe(map(transformDateResponse));

@Injectable()
export class DateInterceptor implements HttpInterceptor {
  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
    return next.handle(req).pipe(map(transformDateResponse));
  }
}
```

Scoped client interceptors now also expose a functional variant, for example:

```ts
export const defaultBaseInterceptor: HttpInterceptorFn = (req, next) =>
  interceptClientRequest(
    req,
    { handle: next },
    inject(HTTP_INTERCEPTORS_DEFAULT),
    CLIENT_CONTEXT_TOKEN_DEFAULT,
  );
```