### PR TITLE
feat(date-transformer): customizable date regex with broader default

### DIFF
--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -45,6 +45,19 @@ Interceptors can be re-used across different clients.
 
 If disabled, [Date Transformer Interceptor](utilities/date-transformer.md) will not be applied to the HTTP client. This means date strings will not be automatically converted to `Date` objects.
 
+### `dateTransformRegex`
+
+**Type:** `RegExp` | **Default:** [`ISO_DATE_REGEX`](utilities/date-transformer.md#recognized-formats)
+
+Overrides the pattern the [Date Transformer Interceptor](utilities/date-transformer.md) uses to detect which string values are dates. Use it when your API returns a format the default pattern doesn't cover, without having to copy the generated `date-transformer.ts`. Only available when the client was generated with `dateType: 'Date'`.
+
+```typescript
+provideNgOpenapi({
+    basePath: "https://api.example.com",
+    dateTransformRegex: /your-custom-pattern/,
+});
+```
+
 ## Manual Configuration
 
 If you prefer to manually configure the OpenAPI client without using the provider, you can do so by setting up the `BASE_PATH` token in the providers. This is useful for more complex scenarios where you need fine-grained control over the configuration.

--- a/docs/api/utilities/date-transformer.md
+++ b/docs/api/utilities/date-transformer.md
@@ -38,9 +38,9 @@ import { Injectable } from "@angular/core";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 
-export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z?$/;
+export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/;
 
-export function transformDates(obj: any): any {
+export function transformDates(obj: any, dateRegex: RegExp = ISO_DATE_REGEX): any {
     if (obj === null || obj === undefined || typeof obj !== "object") {
         return obj;
     }
@@ -50,17 +50,17 @@ export function transformDates(obj: any): any {
     }
 
     if (Array.isArray(obj)) {
-        return obj.map((item) => transformDates(item));
+        return obj.map((item) => transformDates(item, dateRegex));
     }
 
     if (typeof obj === "object") {
         const transformed: any = {};
         for (const key of Object.keys(obj)) {
             const value = obj[key];
-            if (typeof value === "string" && ISO_DATE_REGEX.test(value)) {
+            if (typeof value === "string" && dateRegex.test(value)) {
                 transformed[key] = new Date(value);
             } else {
-                transformed[key] = transformDates(value);
+                transformed[key] = transformDates(value, dateRegex);
             }
         }
         return transformed;
@@ -71,15 +71,55 @@ export function transformDates(obj: any): any {
 
 @Injectable()
 export class DateInterceptor implements HttpInterceptor {
+    /** @param dateRegex Optional override for the pattern used to detect ISO date strings. */
+    constructor(private readonly dateRegex: RegExp = ISO_DATE_REGEX) {}
+
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(req).pipe(
             map((event) => {
                 if (event instanceof HttpResponse && event.body) {
-                    return event.clone({ body: transformDates(event.body) });
+                    return event.clone({ body: transformDates(event.body, this.dateRegex) });
                 }
                 return event;
             }),
         );
     }
 }
+```
+
+## Recognized Formats
+
+`ISO_DATE_REGEX` matches a full RFC 3339 / ISO 8601 date-time with optional
+fractional seconds (of any length) and an optional `Z` or numeric timezone offset
+(`±hh:mm` or `±hhmm`):
+
+- `2024-01-15T10:30:00Z`
+- `2024-01-15T10:30:00.123Z`
+- `2024-01-15T10:30:00.04` — any number of fractional-second digits
+- `2024-01-15T10:30:00.7559265+02:00` — numeric timezone offset
+- `2024-01-15T10:30:00+0200` — offset without colon
+- `2024-01-15T10:30:00`
+
+The pattern is intentionally strict (full date-time only) so plain strings such as
+a bare year (`"2024"`) or a numeric ID are never accidentally turned into `Date`
+objects.
+
+## Customizing the Regex
+
+If your API uses a format the default pattern doesn't cover, override it via the
+provider instead of editing the generated file:
+
+```typescript
+provideNgOpenapi({
+    basePath: "https://api.example.com",
+    dateTransformRegex: /your-custom-pattern/,
+});
+```
+
+Both `transformDates` and `DateInterceptor` accept the regex directly as well, for
+manual interceptor setups:
+
+```typescript
+new DateInterceptor(/your-custom-pattern/);
+transformDates(responseBody, /your-custom-pattern/);
 ```

--- a/docs/api/utilities/date-transformer.md
+++ b/docs/api/utilities/date-transformer.md
@@ -38,7 +38,7 @@ import { Injectable } from "@angular/core";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 
-export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z?$/;
+export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z?$/;
 
 export function transformDates(obj: any): any {
     if (obj === null || obj === undefined || typeof obj !== "object") {

--- a/docs/guide/date-handling.md
+++ b/docs/guide/date-handling.md
@@ -114,13 +114,14 @@ export const appConfig: ApplicationConfig = {
 The date transformer uses this regex to identify date strings:
 
 ```typescript
-export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z?$/;
+export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z?$/;
 ```
 
 Matches formats like:
 
 - `2024-01-15T10:30:00Z`
 - `2024-01-15T10:30:00.123Z`
+- `2024-01-15T10:30:00.04` (any number of fractional-second digits)
 - `2024-01-15T10:30:00`
 
 ## Resources

--- a/docs/guide/date-handling.md
+++ b/docs/guide/date-handling.md
@@ -114,7 +114,7 @@ export const appConfig: ApplicationConfig = {
 The date transformer uses this regex to identify date strings:
 
 ```typescript
-export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z?$/;
+export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/;
 ```
 
 Matches formats like:
@@ -122,7 +122,34 @@ Matches formats like:
 - `2024-01-15T10:30:00Z`
 - `2024-01-15T10:30:00.123Z`
 - `2024-01-15T10:30:00.04` (any number of fractional-second digits)
+- `2024-01-15T10:30:00.7559265+02:00` (numeric timezone offset, `±hh:mm`)
+- `2024-01-15T10:30:00+0200` (offset without colon, `±hhmm`)
 - `2024-01-15T10:30:00`
+
+The pattern is intentionally strict — it only matches full ISO 8601 date-times so
+that ordinary strings (a bare year like `"2024"`, a numeric ID, etc.) are never
+accidentally converted to `Date` objects.
+
+### Custom Date Regex
+
+If your API returns a format the default pattern doesn't cover, pass your own
+regex via the provider — no need to copy `date-transformer.ts`:
+
+```typescript
+provideNgOpenapi({
+    basePath: "https://api.example.com",
+    // Use any pattern you like; it overrides ISO_DATE_REGEX
+    dateTransformRegex: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/,
+});
+```
+
+`transformDates` and `DateInterceptor` also accept the regex directly, so you can
+reuse them in a manual interceptor setup:
+
+```typescript
+new DateInterceptor(/your-custom-regex/);
+transformDates(responseBody, /your-custom-regex/);
+```
 
 ## Resources
 

--- a/packages/ng-openapi/src/lib/generators/utility/date-transformer.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/utility/date-transformer.generator.ts
@@ -1,4 +1,4 @@
-import { Project, VariableDeclarationKind } from "ts-morph";
+import { Project, Scope, VariableDeclarationKind } from "ts-morph";
 import * as path from "path";
 
 export class DateTransformerGenerator {
@@ -29,14 +29,17 @@ export class DateTransformerGenerator {
             },
         ]);
 
-        // Add ISO date regex constant
+        // Add ISO date regex constant.
+        // Matches a full RFC 3339 / ISO 8601 date-time: optional fractional seconds
+        // of any length and an optional 'Z' or numeric timezone offset (±hh:mm or
+        // ±hhmm).
         sourceFile.addVariableStatement({
             isExported: true,
             declarationKind: VariableDeclarationKind.Const,
             declarations: [
                 {
                     name: "ISO_DATE_REGEX",
-                    initializer: "/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z?$/",
+                    initializer: "/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:?\\d{2})?$/",
                 },
             ],
         });
@@ -45,7 +48,10 @@ export class DateTransformerGenerator {
         sourceFile.addFunction({
             name: "transformDates",
             isExported: true,
-            parameters: [{ name: "obj", type: "any" }],
+            parameters: [
+                { name: "obj", type: "any" },
+                { name: "dateRegex", type: "RegExp", initializer: "ISO_DATE_REGEX" },
+            ],
             returnType: "any",
             statements: `
     if (obj === null || obj === undefined || typeof obj !== 'object') {
@@ -57,17 +63,17 @@ export class DateTransformerGenerator {
     }
 
     if (Array.isArray(obj)) {
-        return obj.map(item => transformDates(item));
+        return obj.map(item => transformDates(item, dateRegex));
     }
 
     if (typeof obj === 'object') {
         const transformed: any = {};
         for (const key of Object.keys(obj)) {
             const value = obj[key];
-            if (typeof value === 'string' && ISO_DATE_REGEX.test(value)) {
+            if (typeof value === 'string' && dateRegex.test(value)) {
                 transformed[key] = new Date(value);
             } else {
-                transformed[key] = transformDates(value);
+                transformed[key] = transformDates(value, dateRegex);
             }
         }
         return transformed;
@@ -87,6 +93,22 @@ export class DateTransformerGenerator {
                 },
             ],
             implements: ["HttpInterceptor"],
+            ctors: [
+                {
+                    docs: [
+                        "@param dateRegex Optional override for the pattern used to detect ISO date strings.",
+                    ],
+                    parameters: [
+                        {
+                            name: "dateRegex",
+                            type: "RegExp",
+                            scope: Scope.Private,
+                            isReadonly: true,
+                            initializer: "ISO_DATE_REGEX",
+                        },
+                    ],
+                },
+            ],
             methods: [
                 {
                     name: "intercept",
@@ -99,7 +121,7 @@ export class DateTransformerGenerator {
     return next.handle(req).pipe(
         map(event => {
             if (event instanceof HttpResponse && event.body) {
-                return event.clone({ body: transformDates(event.body) });
+                return event.clone({ body: transformDates(event.body, this.dateRegex) });
             }
             return event;
         })

--- a/packages/ng-openapi/src/lib/generators/utility/date-transformer.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/utility/date-transformer.generator.ts
@@ -36,7 +36,7 @@ export class DateTransformerGenerator {
             declarations: [
                 {
                     name: "ISO_DATE_REGEX",
-                    initializer: "/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3})?Z?$/",
+                    initializer: "/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z?$/",
                 },
             ],
         });

--- a/packages/ng-openapi/src/lib/generators/utility/provider.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/utility/provider.generator.ts
@@ -1,4 +1,4 @@
-import { Project } from "ts-morph";
+import { OptionalKind, Project, PropertySignatureStructure } from "ts-morph";
 import * as path from "path";
 import {
     GeneratorConfig,
@@ -57,29 +57,43 @@ export class ProviderGenerator {
         }
 
         // Add config interface
+        const configProperties: OptionalKind<PropertySignatureStructure>[] = [
+            {
+                name: "basePath",
+                type: "string",
+                docs: ["Base API URL"],
+            },
+            {
+                name: "enableDateTransform",
+                type: "boolean",
+                hasQuestionToken: true,
+                docs: ["Enable automatic date transformation (default: true)"],
+            },
+            {
+                name: "interceptors",
+                type: "(new (...args: HttpInterceptor[]) => HttpInterceptor)[]",
+                hasQuestionToken: true,
+                docs: ["Array of HTTP interceptor classes to apply to this client"],
+            },
+        ];
+
+        if (this.config.options.dateType === "Date") {
+            configProperties.push({
+                name: "dateTransformRegex",
+                type: "RegExp",
+                hasQuestionToken: true,
+                docs: [
+                    "Override the pattern used to detect ISO date strings during date transformation.",
+                    "Defaults to the generated ISO_DATE_REGEX.",
+                ],
+            });
+        }
+
         sourceFile.addInterface({
             name: `${this.capitalizeFirst(this.clientName)}Config`,
             isExported: true,
             docs: [`Configuration options for ${this.clientName} client`],
-            properties: [
-                {
-                    name: "basePath",
-                    type: "string",
-                    docs: ["Base API URL"],
-                },
-                {
-                    name: "enableDateTransform",
-                    type: "boolean",
-                    hasQuestionToken: true,
-                    docs: ["Enable automatic date transformation (default: true)"],
-                },
-                {
-                    name: "interceptors",
-                    type: "(new (...args: HttpInterceptor[]) => HttpInterceptor)[]",
-                    hasQuestionToken: true,
-                    docs: ["Array of HTTP interceptor classes to apply to this client"],
-                },
-            ],
+            properties: configProperties,
         });
 
         // Add main provider function
@@ -122,7 +136,7 @@ if (config.interceptors && config.interceptors.length > 0) {
         hasDateInterceptor
             ? `// Add date interceptor if enabled (default: true)
     if (config.enableDateTransform !== false) {
-        interceptorInstances.unshift(new DateInterceptor());
+        interceptorInstances.unshift(new DateInterceptor(config.dateTransformRegex));
     }`
             : `// Date transformation not available (dateType: 'string' was used in generation)`
     }
@@ -137,7 +151,7 @@ if (config.interceptors && config.interceptors.length > 0) {
     // Only date interceptor enabled
     providers.push({
         provide: ${interceptorsTokenName},
-        useValue: [new DateInterceptor()]
+        useValue: [new DateInterceptor(config.dateTransformRegex)]
     });
 }`
                 : ``


### PR DESCRIPTION
Closes #75
Closes #86

## Summary

<!-- 1–3 bullets on what changed and why. Link the issue if there is one (Closes #123). -->

ISO_DATE_REGEX required exactly 3 fractional-second digits, so timestamps like 2026-07-07T01:02:03.04 were left as strings instead of being converted to Date. Use (\.\d+)? to match any number of fractional digits.

## Checklist

- [ ] PR title follows Conventional Commits (see comment above)
- [ ] Updated docs under `docs/` if user-facing behavior changed
- [ ] Tested locally against a representative OpenAPI spec
