### PR TITLE
docs(http-resource): remove experimental warning

### DIFF
--- a/docs/guide/http-resource.md
+++ b/docs/guide/http-resource.md
@@ -4,11 +4,7 @@ title: HTTP Resource Plugin
 
 # HTTP Resource Plugin
 
-Generate Angular services using the experimental `httpResource` API for automatic caching, state management, and reactive data loading.
-
-:::warning Experimental Feature
-`httpResource` is still experimental in Angular. Use with caution in production environments.
-:::
+Generate Angular services using the `httpResource` API for automatic caching, state management, and reactive data loading.
 
 ## Overview
 
@@ -174,11 +170,10 @@ export class SearchComponent {
 | **Reactivity**            | ✅ Signal-based           | ❌ Observable-based        |
 | **Parameter Binding**     | ✅ Signal or static       | ❌ Manual subscription     |
 | **Request Deduplication** | ✅ Automatic              | ❌ Manual implementation   |
-| **Maturity**              | ⚠️ Experimental           | ✅ Stable                  |
+| **Maturity**              | ✅ Stable                 | ✅ Stable                  |
 
 ## Limitations
 
-- **Experimental API**: Subject to change in future Angular versions
 - **GET Requests Only**: Currently optimized for "GET" requests (see [Angular Docs ↗️](https://angular.dev/guide/http/http-resource))
 
 ## Resources


### PR DESCRIPTION
Starting with Angular v22, all `resource` APIs are stable and fully supported. See the `Asynchronous Reactivity: a new frontier` section in the Angular v22 release article: https://blog.angular.dev/announcing-angular-v22-c52bb83a4664

<!--
Thanks for contributing to ng-openapi!

Your PR title MUST follow Conventional Commits format — it becomes the squash-merge commit message and the changelog entry. The CI will fail otherwise.

  <type>(<scope>): <short description>

Allowed types:
  feat      → new feature (patch bump pre-1.0)
  fix       → bug fix (patch bump pre-1.0)
  perf      → performance improvement
  deps      → dependency update
  revert    → revert a previous commit
  docs      → documentation only (no release)
  refactor  → internal refactor (no release)
  test      → tests only (no release)
  build     → build system / tooling (no release)
  ci        → CI config (no release)
  chore     → other maintenance (no release)
  style     → formatting only (no release)

Add ! before the colon for breaking changes (minor bump pre-1.0):
  feat(generator)!: rename `customizeMethodName` option

Scopes (use one when relevant):
  ng-openapi, http-resource, zod, generator, file-download.generator, ci, deps, ...

Examples:
  fix(file-download.generator): handle undefined under strict typings
  feat(zod): emit discriminated unions for oneOf with discriminator
  perf(generator): cache resolved $refs across operations
-->

## Summary

<!-- 1–3 bullets on what changed and why. Link the issue if there is one (Closes #123). -->
Removes the warnings and hints about the experimental status of the httpResource feature. Since Angular v22, the `resource` Family of APIs is stable.

-

## How to verify

<!-- Steps a reviewer can run locally, or a description of what to look for in the generated output. -->

-

## Checklist

- [x ] PR title follows Conventional Commits (see comment above)
- [x ] Updated docs under `docs/` if user-facing behavior changed
- [ n/a] Tested locally against a representative OpenAPI spec
