### PR TITLE
fix(generator): type OpenAPI security schemes

### DIFF
--- a/packages/shared/src/types/swagger.types.ts
+++ b/packages/shared/src/types/swagger.types.ts
@@ -42,6 +42,17 @@ export interface SwaggerResponse {
     content?: Record<string, { schema?: any }>;
 }
 
+export interface OpenApiSecurityScheme {
+    type?: "apiKey" | "http" | "oauth2" | "openIdConnect";
+    description?: string;
+    name?: string;
+    in?: "query" | "header" | "cookie";
+    scheme?: string;
+    bearerFormat?: string;
+    flows?: Record<string, any>;
+    openIdConnectUrl?: string;
+}
+
 export interface SwaggerDefinition {
     type?: ParameterType | undefined;
     format?: string | undefined;
@@ -97,6 +108,7 @@ export interface SwaggerSpec {
     tags?: Tag[] | undefined;
     components?: {
         schemas?: Record<string, SwaggerDefinition>;
+        securitySchemes?: Record<string, OpenApiSecurityScheme | Security>;
     };
 }
 


### PR DESCRIPTION
## Summary

- Add a shared OpenAPI security scheme type.
- Include `components.securitySchemes` on `SwaggerSpec` for OpenAPI 3 documents.

## How to verify

- `npx tsc -p packages/shared/tsconfig.lib.json --noEmit`
- `npx prettier --check packages/shared/src/types/swagger.types.ts`
- `git diff --check`

## Checklist

- [x] PR title follows Conventional Commits (see comment above)
- [x] Docs unchanged because this only updates TypeScript types
- [x] Typechecked the shared OpenAPI type surface locally
