### PR TITLE
fix(shared): treat dots as word separators in camelCase and pascalCase

### DIFF
--- a/packages/shared/src/utils/string.utils.ts
+++ b/packages/shared/src/utils/string.utils.ts
@@ -1,6 +1,6 @@
 export function camelCase(str: string): string {
     return str
-        .replace(/[-_\s]+(.)?/g, (_, char) => (char ? char.toUpperCase() : ""))
+        .replace(/[-_.\s]+(.)?/g, (_, char) => (char ? char.toUpperCase() : ""))
         .replace(/^./, (char) => char.toLowerCase());
 }
 
@@ -13,7 +13,7 @@ export function kebabCase(str: string): string {
 
 export function pascalCase(str: string): string {
     return str
-        .replace(/[-_\s]+(.)?/g, (_, char) => (char ? char.toUpperCase() : ""))
+        .replace(/[-_.\s]+(.)?/g, (_, char) => (char ? char.toUpperCase() : ""))
         .replace(/^./, (char) => char.toUpperCase());
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to ng-openapi!

Your PR title MUST follow Conventional Commits format — it becomes the squash-merge commit message and the changelog entry. The CI will fail otherwise.

  <type>(<scope>): <short description>

Allowed types:
  feat      → new feature (patch bump pre-1.0)
  fix       → bug fix (patch bump pre-1.0)
  perf      → performance improvement
  deps      → dependency update
  revert    → revert a previous commit
  docs      → documentation only (no release)
  refactor  → internal refactor (no release)
  test      → tests only (no release)
  build     → build system / tooling (no release)
  ci        → CI config (no release)
  chore     → other maintenance (no release)
  style     → formatting only (no release)

Add ! before the colon for breaking changes (minor bump pre-1.0):
  feat(generator)!: rename `customizeMethodName` option

Scopes (use one when relevant):
  ng-openapi, http-resource, zod, generator, file-download.generator, ci, deps, ...

Examples:
  fix(file-download.generator): handle undefined under strict typings
  feat(zod): emit discriminated unions for oneOf with discriminator
  perf(generator): cache resolved $refs across operations
-->

## Summary

Dotted parameter names from ASP.NET Core [FromQuery] complex objects (e.g. Page.CurrentPage) passed through camelCase unchanged and produced invalid TypeScript identifiers in generated method signatures. Dots now camelCase like hyphens/underscores (Page.CurrentPage -> pageCurrentPage) while the original dotted name is still sent as the query key, so no backend changes are needed. Same fix applied to pascalCase for service class and model interface names derived from dotted tags/schema names.

Closes #89

## How to verify

<!-- Steps a reviewer can run locally, or a description of what to look for in the generated output. -->

-

## Checklist

- [x] PR title follows Conventional Commits (see comment above)
- [x] Updated docs under `docs/` if user-facing behavior changed
- [x] Tested locally against a representative OpenAPI spec
