### PR TITLE
fix(ng-openapi): avoid fixMissingImports crash in request-params generation

### DIFF
--- a/packages/ng-openapi/src/lib/generators/service/request-params.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/service/request-params.generator.ts
@@ -1,4 +1,4 @@
-import { Project } from "ts-morph";
+import { Project, SourceFile } from "ts-morph";
 import {
     GeneratorConfig,
     pascalCase,
@@ -73,13 +73,38 @@ export class RequestParamsGenerator {
             });
         });
 
-        // fixMissingImports before the header comment: inserting the first import
-        // into a file that starts with plain comment text trips up ts-morph
-        sourceFile.fixMissingImports().formatText();
+        // Imports before the header comment: inserting the first import into a
+        // file that starts with plain comment text trips up ts-morph
+        this.addMissingImports(sourceFile);
+        sourceFile.formatText();
         sourceFile.insertText(0, REQUEST_PARAMS_GENERATOR_HEADER_COMMENT);
         sourceFile.saveSync();
 
         this.addModelsBarrelExport(outputRoot);
+    }
+
+    /**
+     * `sourceFile.fixMissingImports()` fails with a tree-manipulation error when
+     * the first statement of the file carries a JSDoc (as the interfaces here do),
+     * so the same language-service code fix is applied as a plain text edit instead.
+     */
+    private addMissingImports(sourceFile: SourceFile): void {
+        const changes = this.project
+            .getLanguageService()
+            .getCombinedCodeFix(sourceFile, "fixMissingImport")
+            .getChanges()
+            .filter((fileChange) => fileChange.getFilePath() === sourceFile.getFilePath())
+            .flatMap((fileChange) => fileChange.getTextChanges())
+            .sort((a, b) => b.getSpan().getStart() - a.getSpan().getStart());
+        if (changes.length === 0) {
+            return;
+        }
+        let text = sourceFile.getFullText();
+        changes.forEach((change) => {
+            const span = change.getSpan();
+            text = text.slice(0, span.getStart()) + change.getNewText() + text.slice(span.getStart() + span.getLength());
+        });
+        sourceFile.replaceWithText(text);
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for contributing to ng-openapi!

Your PR title MUST follow Conventional Commits format — it becomes the squash-merge commit message and the changelog entry. The CI will fail otherwise.

  <type>(<scope>): <short description>

Allowed types:
  feat      → new feature (patch bump pre-1.0)
  fix       → bug fix (patch bump pre-1.0)
  perf      → performance improvement
  deps      → dependency update
  revert    → revert a previous commit
  docs      → documentation only (no release)
  refactor  → internal refactor (no release)
  test      → tests only (no release)
  build     → build system / tooling (no release)
  ci        → CI config (no release)
  chore     → other maintenance (no release)
  style     → formatting only (no release)

Add ! before the colon for breaking changes (minor bump pre-1.0):
  feat(generator)!: rename `customizeMethodName` option

Scopes (use one when relevant):
  ng-openapi, http-resource, zod, generator, file-download.generator, ci, deps, ...

Examples:
  fix(file-download.generator): handle undefined under strict typings
  feat(zod): emit discriminated unions for oneOf with discriminator
  perf(generator): cache resolved $refs across operations
-->

## Summary
ts-morph's fixMissingImports fails with "children of the old and new trees were expected to have the same count" when it inserts the first import into a file whose first statement carries a JSDoc comment, which is the case for the operation descriptions on the interfaces in models/request-params.ts. Apply the language service's fixMissingImport code fix as plain text edits followed by a full reparse instead.

## How to verify

<!-- Steps a reviewer can run locally, or a description of what to look for in the generated output. -->

-

## Checklist

- [x] PR title follows Conventional Commits (see comment above)
- [x] Updated docs under `docs/` if user-facing behavior changed
- [x] Tested locally against a representative OpenAPI spec
