### PR TITLE
chore(docs): add Context7 AI chat widget to documentation site

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -84,6 +84,17 @@ export default defineConfig({
         ["meta", { name: "twitter:card", content: "summary_large_image" }],
         ["meta", { name: "twitter:image", content: `${SITE_URL}/og-image.png` }],
 
+        // Context7 AI chat widget (floating chat button on every page)
+        [
+            "script",
+            {
+                src: "https://context7.com/widget.js",
+                "data-library": "/ng-openapi/ng-openapi",
+                "data-color": "#3c82f6",
+                async: "",
+            },
+        ],
+
         // Schema.org structured data for software
         [
             "script",


### PR DESCRIPTION
## Summary
- Add the [Context7](https://context7.com) chat widget to the VitePress docs site via the global `head` array, so the floating AI chat button loads on every page
- Widget is scoped to the `/ng-openapi/ng-openapi` library, uses the existing site theme color (`#3c82f6`), and loads with `async` so it does not block page rendering

## Test plan
- [x] `npm run docs:build` completes successfully
- [x] Verified the rendered `<script src=https://context7.com/widget.js data-library=/ng-openapi/ng-openapi data-color=#3c82f6 async>` tag appears in the built HTML across pages