### PR TITLE
feat: send Accept header derived from response content types

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -283,6 +283,10 @@ export default defineConfig({
                                             link: "/api/configuration/options/custom-headers",
                                         },
                                         {
+                                            text: "Emit Accept Header",
+                                            link: "/api/configuration/options/emit-accept-header",
+                                        },
+                                        {
                                             text: "Response Type Mapping",
                                             link: "/api/configuration/options/response-type-mapping",
                                         },

--- a/docs/api/configuration/options.md
+++ b/docs/api/configuration/options.md
@@ -46,6 +46,7 @@ export default config;
 | [`validation`](options/validation) | `{ response?: boolean }` | — | `undefined` | Adds a `parse` hook to service methods for runtime response validation |
 | [`generateEnumBasedOnDescription`](options/generate-enums-description) | `boolean` | — | `false` | Read enum member names from JSON-encoded descriptions |
 | [`customHeaders`](options/custom-headers) | `Record<string, string>` | — | `undefined` | Default headers added to every request |
+| [`emitAcceptHeader`](options/emit-accept-header) | `boolean` | — | `true` | Send an `Accept` header derived from each operation's response content types |
 | [`responseTypeMapping`](options/response-type-mapping) | `Record<string, ResponseType>` | — | `undefined` | Pin the Angular `responseType` per content type |
 | [`customizeMethodName`](options/customize-method-name) | `(operationId) => string` | — | `undefined` | Derive method names from `operationId`s |
 | [`useSingleRequestParameter`](options/use-single-request-parameter) | `boolean` | — | `false` | One request object per method instead of positional parameters |

--- a/docs/api/configuration/options/emit-accept-header.md
+++ b/docs/api/configuration/options/emit-accept-header.md
@@ -1,0 +1,39 @@
+---
+description: "emitAcceptHeader: send an Accept header derived from each operation's response content types."
+title: Emit Accept Header
+---
+
+# `emitAcceptHeader`
+
+**Type:** `boolean | undefined` | **Default:** `true`
+
+Sends an `Accept` header derived from each operation's response content types, so servers that use content negotiation (for example versioned vendor media types like `application/vnd.users+json;version=1.0`) return the representation the generated method is prepared to parse.
+
+The header value contains the content types declared on the operation's first success response that agree with the method's Angular `responseType` — advertising a type the method could not parse is deliberately avoided. Operations whose success response declares no content (for example `204 No Content`) send no `Accept` header.
+
+The generated code only sets the header when it is not already present, so values from [`customHeaders`](custom-headers) or per-request options always win:
+
+```typescript
+// generated
+if (!headers.has('Accept')) {
+    headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+}
+```
+
+Set `emitAcceptHeader: false` to restore the previous behavior of sending no `Accept` header.
+
+## Usage
+
+```typescript
+// openapi.config.ts
+import { GeneratorConfig } from 'ng-openapi';
+
+const config: GeneratorConfig = {
+  options: {
+    emitAcceptHeader: false, // opt out of the spec-derived Accept header
+  },
+  ... // other configurations
+};
+
+export default config;
+```

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - ng-openapi  (2026-07-06)
 
 ## Corpus Check
-- 223 files · ~61,298 words
+- 224 files · ~62,229 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 1540 nodes · 2452 edges · 163 communities (117 shown, 46 thin omitted)
+- 1546 nodes · 2467 edges · 163 communities (116 shown, 47 thin omitted)
 - Extraction: 99% EXTRACTED · 1% INFERRED · 0% AMBIGUOUS · INFERRED: 13 edges (avg confidence: 0.78)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `d5a26e8d`
+- Built from commit: `db3670ff`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -170,7 +170,7 @@
 - [[_COMMUNITY_namedInputs|namedInputs]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `NormalizedOperation` - 56 edges
+1. `NormalizedOperation` - 58 edges
 2. `SwaggerDefinition` - 49 edges
 3. `scripts` - 35 edges
 4. `GeneratorConfig` - 35 edges
@@ -188,10 +188,10 @@
   packages/testing/src/golden-suite.ts → packages/ng-openapi/tests/generation-result.test.ts
 - `runGeneration()` --calls--> `generateFromConfig()`  [EXTRACTED]
   packages/ng-openapi/src/lib/cli.ts → packages/ng-openapi/src/lib/core/generator.ts
+- `generateFromConfig()` --calls--> `detectAngularCoreVersion()`  [EXTRACTED]
+  packages/ng-openapi/src/lib/core/generator.ts → packages/ng-openapi/src/lib/core/angular-version.ts
 - `generateFromConfig()` --calls--> `validateGeneratorConfig()`  [EXTRACTED]
   packages/ng-openapi/src/lib/core/generator.ts → packages/ng-openapi/src/lib/core/config-validation.ts
-- `issuesOf()` --calls--> `validateGeneratorConfig()`  [EXTRACTED]
-  packages/ng-openapi/tests/config-validation.test.ts → packages/ng-openapi/src/lib/core/config-validation.ts
 
 ## Import Cycles
 - None detected.
@@ -200,35 +200,35 @@
 - **NPM Release Pipeline** — _github_workflows_release_please_release_please_workflow, _github_workflows_publish_publish_workflow, _github_workflows_release_pr_prerelease_workflow [EXTRACTED 0.90]
 - **Monorepo Published Packages** — pkg_ng_openapi, pkg_http_resource, pkg_zod, pkg_shared [EXTRACTED 0.85]
 
-## Communities (163 total, 46 thin omitted)
+## Communities (163 total, 47 thin omitted)
 
 ### Community 0 - "Core Generation Pipeline"
-Cohesion: 0.11
-Nodes (8): detectAngularCoreVersion(), generateFromConfig(), validateInput(), Reporter, DateTransformerGenerator, FileDownloadGenerator, MainIndexGenerator, tmpRoot
+Cohesion: 0.12
+Nodes (6): generateFromConfig(), GenerationResult, Reporter, DateTransformerGenerator, FileDownloadGenerator, MainIndexGenerator
 
 ### Community 1 - "Service Method Generators"
 Cohesion: 0.14
 Nodes (14): File by File, Generated Output, `index.ts`, `models/index.ts`, `models/request-params.ts`, `providers.ts`, Regeneration Notes, `services/*.service.ts` (+6 more)
 
 ### Community 2 - "Method Body Generation"
-Cohesion: 0.18
-Nodes (14): decorate(), getModelTypeName(), getResourceClassName(), getServiceClassName(), hasDuplicateFunctionNames(), generateParseRequestTypeParams(), isDataTypeInterface(), kebabCase() (+6 more)
+Cohesion: 0.08
+Nodes (26): ServiceIndexGenerator, HttpResourceIndexGenerator, ZodIndexGenerator, NameDecoration, CONTENT_TYPES, decorate(), getModelTypeName(), getResourceClassName() (+18 more)
 
 ### Community 3 - "Package Manifests & Exports"
 Cohesion: 0.15
 Nodes (12): bugs, url, description, files, homepage, keywords, license, main (+4 more)
 
 ### Community 4 - "Zod Schema Generation"
-Cohesion: 0.05
-Nodes (28): EnumBuilder, toEnumKey(), InterfaceBuilder, buildSdkTypes(), TypeGenerator, escapeString(), sanitizePropertyName(), TypeResolver (+20 more)
+Cohesion: 0.07
+Nodes (25): EnumBuilder, toEnumKey(), InterfaceBuilder, buildSdkTypes(), TypeGenerator, escapeString(), sanitizePropertyName(), TypeResolver (+17 more)
 
 ### Community 5 - "Documentation & Guides"
 Cohesion: 0.22
 Nodes (9): Generated Structure, Next Steps, Quick Start, Step 1: Prepare Your OpenAPI Specification, Step 2: Generate API Client, Step 3: Configure Your Angular App, Step 4: Use Generated Services, Using Command Line (+1 more)
 
 ### Community 6 - "Type Resolution & Params"
-Cohesion: 0.18
-Nodes (5): buildConfig(), HttpResourceGenerator, ConfigBuilder, registerCompileCheckSuite(), SPEC_SOURCES
+Cohesion: 0.13
+Nodes (8): GenerationPhase, buildConfig(), FIXTURE, tempDirs, tmpRoot, ConfigBuilder, registerCompileCheckSuite(), SPEC_SOURCES
 
 ### Community 7 - "Build Scripts"
 Cohesion: 0.05
@@ -240,7 +240,7 @@ Nodes (22): Key design decisions, ng-openapi — Architecture, One normalized mo
 
 ### Community 9 - "Dev Dependencies"
 Cohesion: 0.07
-Nodes (28): devDependencies, @angular/common, @angular/core, eslint, eslint-config-prettier, @eslint/js, jsonc-eslint-parser, @nx/eslint (+20 more)
+Nodes (27): devDependencies, @angular/common, @angular/core, eslint, eslint-config-prettier, @eslint/js, jsonc-eslint-parser, @nx/eslint (+19 more)
 
 ### Community 10 - "Nx Project Targets"
 Cohesion: 0.08
@@ -299,16 +299,16 @@ Cohesion: 0.04
 Nodes (45): optional, optional, author, email, name, url, bugs, url (+37 more)
 
 ### Community 24 - "Date Transformation"
-Cohesion: 0.20
-Nodes (8): Available Utilities, [Date Transformer](utilities/date-transformer.md), File Download Helper, Generated Source, Usage, [File Download Helper](utilities/file-download-helper.md), Usage, Utilities
+Cohesion: 0.11
+Nodes (14): Available Utilities, Customizing the Regex, Date Transformer, Generated Source, Manual Setup, Recognized Formats, Usage, [Date Transformer](utilities/date-transformer.md) (+6 more)
 
 ### Community 25 - "Plugins Changelog"
-Cohesion: 0.21
+Cohesion: 0.25
 Nodes (10): ConfigBuilder, fixturePath(), FIXTURES_DIR, GOLDEN_FIXTURES, GoldenFixture, GoldenSuiteOptions, listFilesRecursively(), normalizeContent() (+2 more)
 
 ### Community 26 - "Nx Workspace Config"
-Cohesion: 0.15
-Nodes (6): ServiceGenerator, HttpResourceMethodGenerator, HttpResourceMethodBodyGenerator, HttpResourceMethodParamsGenerator, NormalizedOperation, getResponseType()
+Cohesion: 0.22
+Nodes (4): HttpResourceGenerator, HttpResourceMethodGenerator, HttpResourceMethodBodyGenerator, NormalizedOperation
 
 ### Community 27 - "Local Registry Target"
 Cohesion: 0.20
@@ -367,8 +367,8 @@ Cohesion: 0.40
 Nodes (5): optional, optional, peerDependenciesMeta, @angular/common, @angular/core
 
 ### Community 42 - "Angular Peer Deps"
-Cohesion: 0.09
-Nodes (18): Example, `naming`, Notes, Usage, Available Plugins, `HttpResourcePlugin`, Notes, Usage (+10 more)
+Cohesion: 0.14
+Nodes (11): Example, `naming`, Notes, Usage, `HttpResourcePlugin`, Notes, Usage, Notes (+3 more)
 
 ### Community 43 - "Brand Identity & Logo"
 Cohesion: 0.67
@@ -399,8 +399,8 @@ Cohesion: 0.11
 Nodes (17): Advanced Provider Options, Angular Integration, CLI Usage, Command Line Options, Configuration Options, Contributing, 🚀 Easy Setup (Recommended), File Download Example (+9 more)
 
 ### Community 50 - "Enum Generation Options"
-Cohesion: 0.10
-Nodes (15): `customHeaders`, Usage, `generateServices`, Notes, Usage, `options`, Options at a Glance, `responseTypeMapping` (+7 more)
+Cohesion: 0.08
+Nodes (19): `customHeaders`, Usage, `customizeMethodName`, Notes, Usage, `emitAcceptHeader`, Usage, `generateServices` (+11 more)
 
 ### Community 51 - "generator.ts"
 Cohesion: 0.27
@@ -427,7 +427,7 @@ Cohesion: 0.67
 Nodes (3): scripts, build, prepublishOnly
 
 ### Community 57 - "index.ts"
-Cohesion: 0.23
+Cohesion: 0.26
 Nodes (8): detectFormat(), parseSpecContent(), fetchUrlContent(), loadSpecContent(), NgOpenApiError, SpecLoadError, SpecParseError, tempDir
 
 ### Community 58 - "Funding Metadata"
@@ -439,8 +439,8 @@ Cohesion: 0.15
 Nodes (12): CLI, Commands, Configuration File, Direct Generation, Examples, Generate Subcommand, Generation Options, Help and Version (+4 more)
 
 ### Community 60 - "Publish Scripts"
-Cohesion: 0.17
-Nodes (17): emitDefaultHeaderGuards(), emitDefaultHeadersMerge(), emitHeaders(), HeadersEmitOptions, emitQueryParams(), emitSignalAwareQueryParams(), emitResponseTypeOption(), joinRequestOptionEntries() (+9 more)
+Cohesion: 0.19
+Nodes (15): emitDefaultHeaderGuards(), emitDefaultHeadersMerge(), emitHeaders(), HeadersEmitOptions, emitQueryParams(), emitSignalAwareQueryParams(), emitResponseTypeOption(), joinRequestOptionEntries() (+7 more)
 
 ### Community 62 - "Config/Metadata Fragment"
 Cohesion: 0.15
@@ -452,19 +452,19 @@ Nodes (7): optional, peerDependenciesMeta, ng-openapi, ts-morph, zod, optional, 
 
 ### Community 65 - "Config/Metadata Fragment"
 Cohesion: 0.06
-Nodes (44): DEFAULT_OPTIONS, isReferenceObject(), ZodPluginOptions, ZodGenerator, ZodSchemaGenerator, defineConfig(), determineResponseType(), normalizeContentSchemas() (+36 more)
+Nodes (33): BaseInterceptorGenerator, DEFAULT_OPTIONS, isReferenceObject(), ZodPluginOptions, ZodGenerator, ZodSchemaGenerator, BASE_INTERCEPTOR_HEADER_COMMENT(), HTTP_RESOURCE_GENERATOR_HEADER_COMMENT() (+25 more)
 
 ### Community 67 - "peerDependenciesMeta"
 Cohesion: 0.33
 Nodes (3): `@ng-openapi/http-resource`, Changelog, `@ng-openapi/zod`
 
 ### Community 68 - "Config/Metadata Fragment"
-Cohesion: 0.40
-Nodes (4): `compilerOptions`, Notes, Schema, Usage
+Cohesion: 0.18
+Nodes (9): `compilerOptions`, Notes, Schema, Usage, Notes, Parameters, Return Value, Usage (+1 more)
 
 ### Community 69 - "Config/Metadata Fragment"
-Cohesion: 0.10
-Nodes (15): `clientName`, Notes, Usage, `input`, Notes, Supported Formats, Usage, Notes (+7 more)
+Cohesion: 0.50
+Nodes (4): `input`, Notes, Supported Formats, Usage
 
 ### Community 71 - "Config/Metadata Fragment"
 Cohesion: 0.29
@@ -479,8 +479,8 @@ Cohesion: 0.15
 Nodes (13): [Angular Integration](./angular-integration.md), [CLI Usage](./cli-usage.md), [Date Handling](./date-handling.md), Features, [File Downloads](./file-download.md), [Generated Output](./generated-code.md), Guides, [HTTP Resource Plugin](./http-resource.md) (+5 more)
 
 ### Community 78 - "generateFromConfig"
-Cohesion: 0.17
-Nodes (7): GenerationPhase, GenerationResult, FIXTURE, tempDirs, tmpRoot, tempDirs, tmpRoot
+Cohesion: 0.09
+Nodes (18): ServiceGenerator, determineResponseInfo(), normalizeContentSchemas(), normalizeOperation(), normalizeOperationSchemas(), normalizeSchema(), normalizeSpec(), resolveBodySchema() (+10 more)
 
 ### Community 79 - "zod.md"
 Cohesion: 0.18
@@ -507,8 +507,8 @@ Cohesion: 0.25
 Nodes (8): Angular Integration, Basic Setup, Configure Providers, Disable Date Transformation, Environment Configuration, Inject Services, Manual Configuration, Resources
 
 ### Community 85 - "author"
-Cohesion: 0.33
-Nodes (6): `'Date'` (Default), `dateType`, Notes, `'string'`, Supported Options, Usage
+Cohesion: 0.17
+Nodes (9): `clientName`, Notes, Usage, `'Date'` (Default), `dateType`, Notes, `'string'`, Supported Options (+1 more)
 
 ### Community 86 - "Contributor Covenant Code of Conduct"
 Cohesion: 0.25
@@ -527,12 +527,8 @@ Cohesion: 0.25
 Nodes (7): Development Dependency (Recommended), Global Installation, Install, Installation, Next Step, Prerequisites, Verify Installation
 
 ### Community 91 - "guides.md"
-Cohesion: 0.27
-Nodes (3): Example using Zod, Overview, Schema Validation
-
-### Community 92 - "ServiceMethodOverloadsGenerator"
-Cohesion: 0.33
-Nodes (6): Customizing the Regex, Date Transformer, Generated Source, Manual Setup, Recognized Formats, Usage
+Cohesion: 0.18
+Nodes (6): Notes, `output`, Usage, Example using Zod, Overview, Schema Validation
 
 ### Community 93 - "ServiceMethodParamsGenerator"
 Cohesion: 0.40
@@ -545,10 +541,6 @@ Nodes (4): author, email, name, url
 ### Community 95 - "index.md"
 Cohesion: 0.40
 Nodes (4): Introduction, Quick Example, Support the Project, What's Included
-
-### Community 96 - "customize-method-name.md"
-Cohesion: 0.50
-Nodes (3): `customizeMethodName`, Notes, Usage
 
 ### Community 97 - "Changelog"
 Cohesion: 0.15
@@ -567,8 +559,8 @@ Cohesion: 0.50
 Nodes (4): repository, directory, type, url
 
 ### Community 101 - "namedInputs"
-Cohesion: 0.31
-Nodes (5): BaseInterceptorGenerator, BASE_INTERCEPTOR_HEADER_COMMENT(), HTTP_RESOURCE_GENERATOR_HEADER_COMMENT(), SERVICE_GENERATOR_HEADER_COMMENT(), ZOD_PLUGIN_GENERATOR_HEADER_COMMENT()
+Cohesion: 0.50
+Nodes (4): Example, Notes, `serviceDecorator`, Usage
 
 ### Community 102 - "Changelog"
 Cohesion: 0.25
@@ -599,24 +591,28 @@ Cohesion: 0.67
 Nodes (3): scripts, build, prepublishOnly
 
 ### Community 110 - "client-name.md"
-Cohesion: 0.17
-Nodes (5): ServiceIndexGenerator, HttpResourceIndexGenerator, ZodIndexGenerator, NameDecoration, listGeneratedFileNames()
+Cohesion: 0.50
+Nodes (4): Available Plugins, Notes, `plugins`, Usage
 
 ### Community 111 - "`input`"
-Cohesion: 0.32
-Nodes (3): RequestObjectEntry, ServiceMethodRequestObjectGenerator, config
+Cohesion: 0.24
+Nodes (3): ServiceMethodGenerator, RequestObjectEntry, ServiceMethodRequestObjectGenerator
 
 ### Community 113 - "validation.md"
 Cohesion: 0.50
-Nodes (3): Resources, Usage, `validation`
+Nodes (4): Plugin Authoring, Rules of engagement, The contract, What the context provides
 
 ### Community 156 - "output.md"
-Cohesion: 0.22
-Nodes (3): ServiceMethodGenerator, ServiceMethodBodyGenerator, MethodGenOptions
+Cohesion: 0.31
+Nodes (3): ServiceMethodBodyGenerator, getRequestBodyType(), config
+
+### Community 158 - "BaseInterceptorGenerator"
+Cohesion: 0.21
+Nodes (3): HttpResourceMethodParamsGenerator, MethodGenOptions, camelCase()
 
 ### Community 159 - "cli.ts"
-Cohesion: 0.42
-Nodes (7): CliOptions, createConsoleReporter(), generateFromOptions(), loadConfigFile(), program, runGeneration(), isUrl()
+Cohesion: 0.31
+Nodes (8): CliOptions, createConsoleReporter(), generateFromOptions(), loadConfigFile(), program, runGeneration(), validateInput(), isUrl()
 
 ### Community 160 - "no-import-cycles.test.ts"
 Cohesion: 0.29
@@ -631,24 +627,24 @@ Cohesion: 0.67
 Nodes (3): namedInputs, default, sharedGlobals
 
 ## Knowledge Gaps
-- **762 isolated node(s):** `$schema`, `url`, `public_key`, `projectTitle`, `description` (+757 more)
+- **763 isolated node(s):** `$schema`, `url`, `public_key`, `projectTitle`, `description` (+758 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **46 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **47 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `peerDependencies` connect `Author Metadata` to `Package Manifests & Exports`?**
-  _High betweenness centrality (0.049) - this node is a cross-community bridge._
+  _High betweenness centrality (0.051) - this node is a cross-community bridge._
 - **Why does `zod` connect `Author Metadata` to `Angular Peer Deps`?**
-  _High betweenness centrality (0.046) - this node is a cross-community bridge._
-- **Why does `devDependencies` connect `Dev Dependencies` to `zod.md`, `Build Scripts`?**
+  _High betweenness centrality (0.048) - this node is a cross-community bridge._
+- **Why does `devDependencies` connect `Dev Dependencies` to `Angular Peer Deps`, `zod.md`, `Build Scripts`?**
   _High betweenness centrality (0.042) - this node is a cross-community bridge._
 - **What connects `$schema`, `url`, `public_key` to the rest of the system?**
-  _764 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _765 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Core Generation Pipeline` be split into smaller, more focused modules?**
-  _Cohesion score 0.10826210826210826 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.12318840579710146 - nodes in this community are weakly interconnected._
 - **Should `Service Method Generators` be split into smaller, more focused modules?**
   _Cohesion score 0.14285714285714285 - nodes in this community are weakly interconnected._
-- **Should `Zod Schema Generation` be split into smaller, more focused modules?**
-  _Cohesion score 0.05362614913176711 - nodes in this community are weakly interconnected._
+- **Should `Method Body Generation` be split into smaller, more focused modules?**
+  _Cohesion score 0.08350168350168351 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -217,7 +217,7 @@
       "label": "buildEnd()",
       "file_type": "code",
       "source_file": "docs/.vitepress/config.ts",
-      "source_location": "L380",
+      "source_location": "L384",
       "_origin": "ast",
       "id": "docs_vitepress_config_buildend",
       "community": 28,
@@ -1270,7 +1270,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "package_devdependencies_zod",
-      "community": 9,
+      "community": 42,
       "norm_label": "zod"
     },
     {
@@ -2090,7 +2090,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_index",
-      "community": 78,
+      "community": 6,
       "norm_label": "index.ts"
     },
     {
@@ -2170,7 +2170,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_core_angular_version",
-      "community": 0,
+      "community": 96,
       "norm_label": "angular-version.ts"
     },
     {
@@ -2180,7 +2180,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_core_angular_version_detectangularcoreversion",
-      "community": 0,
+      "community": 96,
       "norm_label": "detectangularcoreversion()"
     },
     {
@@ -2270,7 +2270,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_core_generator_validateinput",
-      "community": 0,
+      "community": 159,
       "norm_label": "validateinput()"
     },
     {
@@ -2290,7 +2290,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_core_index",
-      "community": 78,
+      "community": 0,
       "norm_label": "index.ts"
     },
     {
@@ -2300,7 +2300,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_core_reporter",
-      "community": 78,
+      "community": 0,
       "norm_label": "reporter.ts"
     },
     {
@@ -2310,7 +2310,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_core_reporter_generationphase",
-      "community": 78,
+      "community": 6,
       "norm_label": "generationphase"
     },
     {
@@ -2350,7 +2350,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_core_reporter_generationresult",
-      "community": 78,
+      "community": 0,
       "norm_label": "generationresult"
     },
     {
@@ -2460,7 +2460,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_index_generator",
-      "community": 111,
+      "community": 2,
       "norm_label": "service-index.generator.ts"
     },
     {
@@ -2470,7 +2470,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_index_generator_serviceindexgenerator",
-      "community": 110,
+      "community": 2,
       "norm_label": "serviceindexgenerator"
     },
     {
@@ -2480,7 +2480,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_index_generator_serviceindexgenerator_constructor",
-      "community": 110,
+      "community": 2,
       "norm_label": ".constructor()"
     },
     {
@@ -2490,7 +2490,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_index_generator_serviceindexgenerator_generateindex",
-      "community": 110,
+      "community": 2,
       "norm_label": ".generateindex()"
     },
     {
@@ -2510,7 +2510,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_generator_servicemethodgenerator",
-      "community": 156,
+      "community": 111,
       "norm_label": "servicemethodgenerator"
     },
     {
@@ -2520,7 +2520,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_generator_servicemethodgenerator_constructor",
-      "community": 156,
+      "community": 158,
       "norm_label": ".constructor()"
     },
     {
@@ -2530,7 +2530,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_generator_servicemethodgenerator_addservicemethod",
-      "community": 156,
+      "community": 111,
       "norm_label": ".addservicemethod()"
     },
     {
@@ -2540,7 +2540,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_generator_servicemethodgenerator_generatesinglerequestparameters",
-      "community": 156,
+      "community": 111,
       "norm_label": ".generatesinglerequestparameters()"
     },
     {
@@ -2550,7 +2550,7 @@
       "source_location": "L57",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_generator_servicemethodgenerator_generatemethodname",
-      "community": 156,
+      "community": 111,
       "norm_label": ".generatemethodname()"
     },
     {
@@ -2560,7 +2560,7 @@
       "source_location": "L70",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_generator_servicemethodgenerator_generatereturntype",
-      "community": 156,
+      "community": 111,
       "norm_label": ".generatereturntype()"
     },
     {
@@ -2570,7 +2570,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_generator_servicemethodgenerator_defaultnamegenerator",
-      "community": 156,
+      "community": 111,
       "norm_label": ".defaultnamegenerator()"
     },
     {
@@ -2627,7 +2627,7 @@
       "label": ".generateMultipartFormData()",
       "file_type": "code",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L39",
+      "source_location": "L40",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatemultipartformdata",
       "community": 156,
@@ -2637,7 +2637,7 @@
       "label": ".generateUrlEncodedFormData()",
       "file_type": "code",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L80",
+      "source_location": "L81",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generateurlencodedformdata",
       "community": 156,
@@ -2647,10 +2647,10 @@
       "label": ".generateHttpRequest()",
       "file_type": "code",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L113",
+      "source_location": "L114",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatehttprequest",
-      "community": 60,
+      "community": 156,
       "norm_label": ".generatehttprequest()"
     },
     {
@@ -2670,7 +2670,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_overloads_generator_servicemethodoverloadsgenerator",
-      "community": 158,
+      "community": 89,
       "norm_label": "servicemethodoverloadsgenerator"
     },
     {
@@ -2690,7 +2690,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_overloads_generator_servicemethodoverloadsgenerator_generatemethodoverloads",
-      "community": 158,
+      "community": 89,
       "norm_label": ".generatemethodoverloads()"
     },
     {
@@ -2700,7 +2700,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_overloads_generator_servicemethodoverloadsgenerator_generatemethodoverload",
-      "community": 158,
+      "community": 89,
       "norm_label": ".generatemethodoverload()"
     },
     {
@@ -2710,7 +2710,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_overloads_generator_servicemethodoverloadsgenerator_generatesinglerequestoverloadparameters",
-      "community": 158,
+      "community": 89,
       "norm_label": ".generatesinglerequestoverloadparameters()"
     },
     {
@@ -2720,7 +2720,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_overloads_generator_servicemethodoverloadsgenerator_generateoverloadparameters",
-      "community": 158,
+      "community": 89,
       "norm_label": ".generateoverloadparameters()"
     },
     {
@@ -2730,7 +2730,7 @@
       "source_location": "L75",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_overloads_generator_servicemethodoverloadsgenerator_addoverloadoptionsparameter",
-      "community": 158,
+      "community": 89,
       "norm_label": ".addoverloadoptionsparameter()"
     },
     {
@@ -2740,7 +2740,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_overloads_generator_servicemethodoverloadsgenerator_generateoverloadresponsetype",
-      "community": 158,
+      "community": 89,
       "norm_label": ".generateoverloadresponsetype()"
     },
     {
@@ -2750,7 +2750,7 @@
       "source_location": "L104",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_overloads_generator_servicemethodoverloadsgenerator_generateoverloadreturntype",
-      "community": 158,
+      "community": 89,
       "norm_label": ".generateoverloadreturntype()"
     },
     {
@@ -2760,7 +2760,7 @@
       "source_location": "L117",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_overloads_generator_servicemethodoverloadsgenerator_gethttprequestoptionsparameter",
-      "community": 158,
+      "community": 89,
       "norm_label": ".gethttprequestoptionsparameter()"
     },
     {
@@ -2780,7 +2780,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_params_generator_servicemethodparamsgenerator",
-      "community": 89,
+      "community": 92,
       "norm_label": "servicemethodparamsgenerator"
     },
     {
@@ -2790,7 +2790,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_params_generator_servicemethodparamsgenerator_constructor",
-      "community": 89,
+      "community": 158,
       "norm_label": ".constructor()"
     },
     {
@@ -2800,7 +2800,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_params_generator_servicemethodparamsgenerator_generatemethodparameters",
-      "community": 89,
+      "community": 92,
       "norm_label": ".generatemethodparameters()"
     },
     {
@@ -2810,7 +2810,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_params_generator_servicemethodparamsgenerator_generateapiparameters",
-      "community": 89,
+      "community": 92,
       "norm_label": ".generateapiparameters()"
     },
     {
@@ -2820,7 +2820,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_params_generator_servicemethodparamsgenerator_addoptionsparameter",
-      "community": 89,
+      "community": 92,
       "norm_label": ".addoptionsparameter()"
     },
     {
@@ -2830,7 +2830,7 @@
       "source_location": "L100",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_params_generator_servicemethodparamsgenerator_gethttprequestoptionsparameter",
-      "community": 89,
+      "community": 92,
       "norm_label": ".gethttprequestoptionsparameter()"
     },
     {
@@ -2840,7 +2840,7 @@
       "source_location": "L118",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_params_generator_servicemethodparamsgenerator_getrequestbodytype",
-      "community": 89,
+      "community": 92,
       "norm_label": ".getrequestbodytype()"
     },
     {
@@ -2850,7 +2850,7 @@
       "source_location": "L130",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_params_generator_servicemethodparamsgenerator_convertobjecttosingleparams",
-      "community": 89,
+      "community": 92,
       "norm_label": ".convertobjecttosingleparams()"
     },
     {
@@ -2910,7 +2910,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_request_object_generator_servicemethodrequestobjectgenerator_torequestparameter",
-      "community": 156,
+      "community": 111,
       "norm_label": ".torequestparameter()"
     },
     {
@@ -2930,7 +2930,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_request_object_generator_servicemethodrequestobjectgenerator_todestructurestatement",
-      "community": 156,
+      "community": 111,
       "norm_label": ".todestructurestatement()"
     },
     {
@@ -2960,7 +2960,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_generator_servicegenerator",
-      "community": 26,
+      "community": 78,
       "norm_label": "servicegenerator"
     },
     {
@@ -2970,7 +2970,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_generator_servicegenerator_constructor",
-      "community": 4,
+      "community": 78,
       "norm_label": ".constructor()"
     },
     {
@@ -2980,7 +2980,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_generator_servicegenerator_generate",
-      "community": 26,
+      "community": 78,
       "norm_label": ".generate()"
     },
     {
@@ -2990,7 +2990,7 @@
       "source_location": "L68",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_generator_servicegenerator_grouppathsbycontroller",
-      "community": 26,
+      "community": 78,
       "norm_label": ".grouppathsbycontroller()"
     },
     {
@@ -3000,7 +3000,7 @@
       "source_location": "L95",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_generator_servicegenerator_generateservicefile",
-      "community": 26,
+      "community": 78,
       "norm_label": ".generateservicefile()"
     },
     {
@@ -3010,7 +3010,7 @@
       "source_location": "L107",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_service_service_generator_servicegenerator_addserviceclass",
-      "community": 26,
+      "community": 78,
       "norm_label": ".addserviceclass()"
     },
     {
@@ -3420,7 +3420,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_utility_base_interceptor_generator",
-      "community": 0,
+      "community": 65,
       "norm_label": "base-interceptor.generator.ts"
     },
     {
@@ -3430,7 +3430,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_utility_base_interceptor_generator_baseinterceptorgenerator",
-      "community": 101,
+      "community": 65,
       "norm_label": "baseinterceptorgenerator"
     },
     {
@@ -3440,7 +3440,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_utility_base_interceptor_generator_baseinterceptorgenerator_constructor",
-      "community": 101,
+      "community": 65,
       "norm_label": ".constructor()"
     },
     {
@@ -3450,7 +3450,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_utility_base_interceptor_generator_baseinterceptorgenerator_generate",
-      "community": 101,
+      "community": 65,
       "norm_label": ".generate()"
     },
     {
@@ -3460,7 +3460,7 @@
       "source_location": "L108",
       "_origin": "ast",
       "id": "packages_ng_openapi_src_lib_generators_utility_base_interceptor_generator_baseinterceptorgenerator_capitalizefirst",
-      "community": 101,
+      "community": 65,
       "norm_label": ".capitalizefirst()"
     },
     {
@@ -3710,7 +3710,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_angular_version_test",
-      "community": 0,
+      "community": 96,
       "norm_label": "angular-version.test.ts"
     },
     {
@@ -3720,7 +3720,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_angular_version_test_tmproot",
-      "community": 0,
+      "community": 96,
       "norm_label": "tmproot"
     },
     {
@@ -3730,7 +3730,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_angular_version_test_fakeworkspace",
-      "community": 0,
+      "community": 96,
       "norm_label": "fakeworkspace()"
     },
     {
@@ -3780,7 +3780,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_generation_result_test",
-      "community": 78,
+      "community": 6,
       "norm_label": "generation-result.test.ts"
     },
     {
@@ -3790,7 +3790,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_generation_result_test_fixture",
-      "community": 78,
+      "community": 6,
       "norm_label": "fixture"
     },
     {
@@ -3800,7 +3800,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_generation_result_test_tmproot",
-      "community": 78,
+      "community": 6,
       "norm_label": "tmproot"
     },
     {
@@ -3810,7 +3810,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_generation_result_test_tempdirs",
-      "community": 78,
+      "community": 6,
       "norm_label": "tempdirs"
     },
     {
@@ -3830,7 +3830,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_golden_test",
-      "community": 25,
+      "community": 6,
       "norm_label": "golden.test.ts"
     },
     {
@@ -3840,7 +3840,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_golden_test_baseconfig",
-      "community": 25,
+      "community": 6,
       "norm_label": "baseconfig()"
     },
     {
@@ -3850,7 +3850,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_perf_benchmark_test",
-      "community": 78,
+      "community": 4,
       "norm_label": "perf-benchmark.test.ts"
     },
     {
@@ -3860,7 +3860,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_perf_benchmark_test_buildlargespec",
-      "community": 78,
+      "community": 4,
       "norm_label": "buildlargespec()"
     },
     {
@@ -3870,7 +3870,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_perf_benchmark_test_tmproot",
-      "community": 78,
+      "community": 4,
       "norm_label": "tmproot"
     },
     {
@@ -3880,7 +3880,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "packages_ng_openapi_tests_perf_benchmark_test_tempdirs",
-      "community": 78,
+      "community": 4,
       "norm_label": "tempdirs"
     },
     {
@@ -5070,7 +5070,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_index_generator",
-      "community": 110,
+      "community": 2,
       "norm_label": "http-resource-index.generator.ts"
     },
     {
@@ -5080,7 +5080,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_index_generator_httpresourceindexgenerator",
-      "community": 110,
+      "community": 2,
       "norm_label": "httpresourceindexgenerator"
     },
     {
@@ -5090,7 +5090,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_index_generator_httpresourceindexgenerator_constructor",
-      "community": 110,
+      "community": 2,
       "norm_label": ".constructor()"
     },
     {
@@ -5100,7 +5100,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_index_generator_httpresourceindexgenerator_generateindex",
-      "community": 110,
+      "community": 2,
       "norm_label": ".generateindex()"
     },
     {
@@ -5110,7 +5110,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_generator",
-      "community": 26,
+      "community": 158,
       "norm_label": "http-resource-method.generator.ts"
     },
     {
@@ -5210,7 +5210,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_constructor",
-      "community": 26,
+      "community": 158,
       "norm_label": ".constructor()"
     },
     {
@@ -5227,27 +5227,37 @@
       "label": ".generateDefaultHeaders()",
       "file_type": "code",
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L28",
+      "source_location": "L29",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generatedefaultheaders",
       "community": 26,
       "norm_label": ".generatedefaultheaders()"
     },
     {
+      "label": ".defaultHeaders()",
+      "file_type": "code",
+      "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
+      "source_location": "L38",
+      "_origin": "ast",
+      "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_defaultheaders",
+      "community": 26,
+      "norm_label": ".defaultheaders()"
+    },
+    {
       "label": ".generateRequestOptions()",
       "file_type": "code",
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L36",
+      "source_location": "L46",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generaterequestoptions",
-      "community": 60,
+      "community": 26,
       "norm_label": ".generaterequestoptions()"
     },
     {
       "label": ".generateHttpResource()",
       "file_type": "code",
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L64",
+      "source_location": "L74",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generatehttpresource",
       "community": 26,
@@ -5260,7 +5270,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_params_generator",
-      "community": 26,
+      "community": 158,
       "norm_label": "http-resource-method-params.generator.ts"
     },
     {
@@ -5270,7 +5280,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_params_generator_httpresourcemethodparamsgenerator",
-      "community": 26,
+      "community": 158,
       "norm_label": "httpresourcemethodparamsgenerator"
     },
     {
@@ -5280,7 +5290,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_params_generator_httpresourcemethodparamsgenerator_constructor",
-      "community": 26,
+      "community": 158,
       "norm_label": ".constructor()"
     },
     {
@@ -5290,7 +5300,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_params_generator_httpresourcemethodparamsgenerator_generatemethodparameters",
-      "community": 26,
+      "community": 158,
       "norm_label": ".generatemethodparameters()"
     },
     {
@@ -5300,7 +5310,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_params_generator_httpresourcemethodparamsgenerator_generateapiparameters",
-      "community": 26,
+      "community": 158,
       "norm_label": ".generateapiparameters()"
     },
     {
@@ -5310,7 +5320,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_params_generator_httpresourcemethodparamsgenerator_addoptionsparameter",
-      "community": 26,
+      "community": 158,
       "norm_label": ".addoptionsparameter()"
     },
     {
@@ -5320,7 +5330,7 @@
       "source_location": "L79",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_params_generator_httpresourcemethodparamsgenerator_getapireturntype",
-      "community": 26,
+      "community": 158,
       "norm_label": ".getapireturntype()"
     },
     {
@@ -5330,7 +5340,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_params_generator_httpresourcemethodparamsgenerator_getresourcerawdatatype",
-      "community": 26,
+      "community": 158,
       "norm_label": ".getresourcerawdatatype()"
     },
     {
@@ -5340,7 +5350,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_method_index",
-      "community": 26,
+      "community": 158,
       "norm_label": "index.ts"
     },
     {
@@ -5350,7 +5360,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_generator",
-      "community": 110,
+      "community": 65,
       "norm_label": "http-resource.generator.ts"
     },
     {
@@ -5360,7 +5370,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_generator_httpresourcegenerator",
-      "community": 6,
+      "community": 26,
       "norm_label": "httpresourcegenerator"
     },
     {
@@ -5370,7 +5380,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_generator_httpresourcegenerator_constructor",
-      "community": 6,
+      "community": 26,
       "norm_label": ".constructor()"
     },
     {
@@ -5380,7 +5390,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_generator_httpresourcegenerator_generate",
-      "community": 6,
+      "community": 26,
       "norm_label": ".generate()"
     },
     {
@@ -5390,7 +5400,7 @@
       "source_location": "L59",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_generator_httpresourcegenerator_grouppathsbycontroller",
-      "community": 6,
+      "community": 26,
       "norm_label": ".grouppathsbycontroller()"
     },
     {
@@ -5400,7 +5410,7 @@
       "source_location": "L85",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_generator_httpresourcegenerator_generateservicefile",
-      "community": 6,
+      "community": 26,
       "norm_label": ".generateservicefile()"
     },
     {
@@ -5410,7 +5420,7 @@
       "source_location": "L95",
       "_origin": "ast",
       "id": "packages_plugins_http_resource_src_lib_http_resource_generator_httpresourcegenerator_addserviceclass",
-      "community": 6,
+      "community": 26,
       "norm_label": ".addserviceclass()"
     },
     {
@@ -6550,7 +6560,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_plugins_zod_src_lib_zod_index_generator",
-      "community": 110,
+      "community": 2,
       "norm_label": "zod-index.generator.ts"
     },
     {
@@ -6560,7 +6570,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "packages_plugins_zod_src_lib_zod_index_generator_zodindexgenerator",
-      "community": 110,
+      "community": 2,
       "norm_label": "zodindexgenerator"
     },
     {
@@ -6570,7 +6580,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "packages_plugins_zod_src_lib_zod_index_generator_zodindexgenerator_constructor",
-      "community": 110,
+      "community": 2,
       "norm_label": ".constructor()"
     },
     {
@@ -6580,7 +6590,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "packages_plugins_zod_src_lib_zod_index_generator_zodindexgenerator_generateindex",
-      "community": 110,
+      "community": 2,
       "norm_label": ".generateindex()"
     },
     {
@@ -7540,7 +7550,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_config_constants",
-      "community": 101,
+      "community": 65,
       "norm_label": "constants.ts"
     },
     {
@@ -7550,7 +7560,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "packages_shared_src_config_constants_service_generator_header_comment",
-      "community": 101,
+      "community": 65,
       "norm_label": "service_generator_header_comment()"
     },
     {
@@ -7560,7 +7570,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "packages_shared_src_config_constants_base_interceptor_header_comment",
-      "community": 101,
+      "community": 65,
       "norm_label": "base_interceptor_header_comment()"
     },
     {
@@ -7570,7 +7580,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "packages_shared_src_config_constants_http_resource_generator_header_comment",
-      "community": 101,
+      "community": 65,
       "norm_label": "http_resource_generator_header_comment()"
     },
     {
@@ -7580,7 +7590,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "packages_shared_src_config_constants_zod_plugin_generator_header_comment",
-      "community": 101,
+      "community": 65,
       "norm_label": "zod_plugin_generator_header_comment()"
     },
     {
@@ -7610,7 +7620,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_config_index",
-      "community": 101,
+      "community": 65,
       "norm_label": "index.ts"
     },
     {
@@ -7620,7 +7630,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_core_index",
-      "community": 65,
+      "community": 78,
       "norm_label": "index.ts"
     },
     {
@@ -7630,88 +7640,88 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_core_normalize",
-      "community": 65,
+      "community": 78,
       "norm_label": "normalize.ts"
     },
     {
       "label": "ResolveRef",
       "file_type": "code",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L10",
+      "source_location": "L11",
       "_origin": "ast",
       "id": "packages_shared_src_core_normalize_resolveref",
-      "community": 65,
+      "community": 78,
       "norm_label": "resolveref"
     },
     {
       "label": "normalizeSpec()",
       "file_type": "code",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L18",
+      "source_location": "L19",
       "_origin": "ast",
       "id": "packages_shared_src_core_normalize_normalizespec",
-      "community": 65,
+      "community": 78,
       "norm_label": "normalizespec()"
     },
     {
       "label": "normalizeSchema()",
       "file_type": "code",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L54",
+      "source_location": "L55",
       "_origin": "ast",
       "id": "packages_shared_src_core_normalize_normalizeschema",
-      "community": 65,
+      "community": 78,
       "norm_label": "normalizeschema()"
     },
     {
       "label": "normalizeOperationSchemas()",
       "file_type": "code",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L120",
+      "source_location": "L121",
       "_origin": "ast",
       "id": "packages_shared_src_core_normalize_normalizeoperationschemas",
-      "community": 65,
+      "community": 78,
       "norm_label": "normalizeoperationschemas()"
     },
     {
       "label": "normalizeContentSchemas()",
       "file_type": "code",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L140",
+      "source_location": "L141",
       "_origin": "ast",
       "id": "packages_shared_src_core_normalize_normalizecontentschemas",
-      "community": 65,
+      "community": 78,
       "norm_label": "normalizecontentschemas()"
     },
     {
       "label": "normalizeOperation()",
       "file_type": "code",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L152",
+      "source_location": "L153",
       "_origin": "ast",
       "id": "packages_shared_src_core_normalize_normalizeoperation",
-      "community": 65,
+      "community": 78,
       "norm_label": "normalizeoperation()"
     },
     {
       "label": "resolveBodySchema()",
       "file_type": "code",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L179",
+      "source_location": "L183",
       "_origin": "ast",
       "id": "packages_shared_src_core_normalize_resolvebodyschema",
-      "community": 65,
+      "community": 78,
       "norm_label": "resolvebodyschema()"
     },
     {
-      "label": "determineResponseType()",
+      "label": "determineResponseInfo()",
       "file_type": "code",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L188",
+      "source_location": "L192",
       "_origin": "ast",
-      "id": "packages_shared_src_core_normalize_determineresponsetype",
-      "community": 65,
-      "norm_label": "determineresponsetype()"
+      "id": "packages_shared_src_core_normalize_determineresponseinfo",
+      "community": 78,
+      "norm_label": "determineresponseinfo()"
     },
     {
       "label": "spec-format.ts",
@@ -7780,7 +7790,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser",
-      "community": 65,
+      "community": 57,
       "norm_label": "swagger-parser.ts"
     },
     {
@@ -7790,7 +7800,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser",
-      "community": 4,
+      "community": 78,
       "norm_label": "swaggerparser"
     },
     {
@@ -7800,7 +7810,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser_constructor",
-      "community": 65,
+      "community": 78,
       "norm_label": ".constructor()"
     },
     {
@@ -7810,7 +7820,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser_create",
-      "community": 4,
+      "community": 0,
       "norm_label": ".create()"
     },
     {
@@ -7820,7 +7830,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser_getnormalizedspec",
-      "community": 4,
+      "community": 78,
       "norm_label": ".getnormalizedspec()"
     },
     {
@@ -7830,7 +7840,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser_getdefinitions",
-      "community": 4,
+      "community": 78,
       "norm_label": ".getdefinitions()"
     },
     {
@@ -7840,7 +7850,7 @@
       "source_location": "L57",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser_getdefinition",
-      "community": 4,
+      "community": 78,
       "norm_label": ".getdefinition()"
     },
     {
@@ -7850,7 +7860,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser_resolvereference",
-      "community": 4,
+      "community": 78,
       "norm_label": ".resolvereference()"
     },
     {
@@ -7860,7 +7870,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser_getalldefinitionnames",
-      "community": 4,
+      "community": 78,
       "norm_label": ".getalldefinitionnames()"
     },
     {
@@ -7870,7 +7880,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser_getspec",
-      "community": 4,
+      "community": 78,
       "norm_label": ".getspec()"
     },
     {
@@ -7880,7 +7890,7 @@
       "source_location": "L78",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser_getpaths",
-      "community": 4,
+      "community": 78,
       "norm_label": ".getpaths()"
     },
     {
@@ -7890,7 +7900,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser_isvalidspec",
-      "community": 4,
+      "community": 78,
       "norm_label": ".isvalidspec()"
     },
     {
@@ -7900,7 +7910,7 @@
       "source_location": "L91",
       "_origin": "ast",
       "id": "packages_shared_src_core_swagger_parser_swaggerparser_getspecversion",
-      "community": 4,
+      "community": 78,
       "norm_label": ".getspecversion()"
     },
     {
@@ -7927,7 +7937,7 @@
       "label": "emitHeaders()",
       "file_type": "code",
       "source_file": "packages/shared/src/emit/headers.emit.ts",
-      "source_location": "L19",
+      "source_location": "L21",
       "_origin": "ast",
       "id": "packages_shared_src_emit_headers_emit_emitheaders",
       "community": 60,
@@ -7937,7 +7947,7 @@
       "label": "emitDefaultHeadersMerge()",
       "file_type": "code",
       "source_file": "packages/shared/src/emit/headers.emit.ts",
-      "source_location": "L64",
+      "source_location": "L74",
       "_origin": "ast",
       "id": "packages_shared_src_emit_headers_emit_emitdefaultheadersmerge",
       "community": 60,
@@ -7947,7 +7957,7 @@
       "label": "emitDefaultHeaderGuards()",
       "file_type": "code",
       "source_file": "packages/shared/src/emit/headers.emit.ts",
-      "source_location": "L79",
+      "source_location": "L89",
       "_origin": "ast",
       "id": "packages_shared_src_emit_headers_emit_emitdefaultheaderguards",
       "community": 60,
@@ -8190,7 +8200,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_index",
-      "community": 111,
+      "community": 4,
       "norm_label": "index.ts"
     },
     {
@@ -8290,7 +8300,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "packages_shared_src_types_config_types_namedecoration",
-      "community": 110,
+      "community": 2,
       "norm_label": "namedecoration"
     },
     {
@@ -8317,7 +8327,7 @@
       "label": "TypeMappingConfig",
       "file_type": "code",
       "source_file": "packages/shared/src/types/config.types.ts",
-      "source_location": "L98",
+      "source_location": "L103",
       "_origin": "ast",
       "id": "packages_shared_src_types_config_types_typemappingconfig",
       "community": 65,
@@ -8327,7 +8337,7 @@
       "label": "TypeGenOptions",
       "file_type": "code",
       "source_file": "packages/shared/src/types/config.types.ts",
-      "source_location": "L108",
+      "source_location": "L113",
       "_origin": "ast",
       "id": "packages_shared_src_types_config_types_typegenoptions",
       "community": 4,
@@ -8337,17 +8347,17 @@
       "label": "MethodGenOptions",
       "file_type": "code",
       "source_file": "packages/shared/src/types/config.types.ts",
-      "source_location": "L123",
+      "source_location": "L128",
       "_origin": "ast",
       "id": "packages_shared_src_types_config_types_methodgenoptions",
-      "community": 156,
+      "community": 158,
       "norm_label": "methodgenoptions"
     },
     {
       "label": "NgOpenapiClientConfig",
       "file_type": "code",
       "source_file": "packages/shared/src/types/config.types.ts",
-      "source_location": "L139",
+      "source_location": "L145",
       "_origin": "ast",
       "id": "packages_shared_src_types_config_types_ngopenapiclientconfig",
       "community": 65,
@@ -8530,7 +8540,7 @@
       "source_location": "L124",
       "_origin": "ast",
       "id": "packages_shared_src_types_swagger_types_swaggerspec",
-      "community": 65,
+      "community": 78,
       "norm_label": "swaggerspec"
     },
     {
@@ -8550,7 +8560,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_utils_content_types_constants",
-      "community": 65,
+      "community": 2,
       "norm_label": "content-types.constants.ts"
     },
     {
@@ -8560,7 +8570,7 @@
       "source_location": "L2",
       "_origin": "ast",
       "id": "packages_shared_src_utils_content_types_constants_content_types",
-      "community": 65,
+      "community": 2,
       "norm_label": "content_types"
     },
     {
@@ -8670,7 +8680,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "packages_shared_src_utils_functions_extract_paths_extractpaths",
-      "community": 65,
+      "community": 78,
       "norm_label": "extractpaths()"
     },
     {
@@ -8680,7 +8690,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "packages_shared_src_utils_functions_extract_paths_parseparameters",
-      "community": 65,
+      "community": 78,
       "norm_label": "parseparameters()"
     },
     {
@@ -8690,47 +8700,67 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_utils_functions_extract_swagger_response_type",
-      "community": 65,
+      "community": 2,
       "norm_label": "extract-swagger-response-type.ts"
+    },
+    {
+      "label": "ResponseTypeInfo",
+      "file_type": "code",
+      "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "packages_shared_src_utils_functions_extract_swagger_response_type_responsetypeinfo",
+      "community": 2,
+      "norm_label": "responsetypeinfo"
     },
     {
       "label": "getResponseTypeFromResponse()",
       "file_type": "code",
       "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L11",
+      "source_location": "L23",
       "_origin": "ast",
       "id": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetypefromresponse",
-      "community": 65,
+      "community": 2,
       "norm_label": "getresponsetypefromresponse()"
+    },
+    {
+      "label": "getResponseInfoFromResponse()",
+      "file_type": "code",
+      "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
+      "source_location": "L36",
+      "_origin": "ast",
+      "id": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponseinfofromresponse",
+      "community": 2,
+      "norm_label": "getresponseinfofromresponse()"
     },
     {
       "label": "isPrimitiveType()",
       "file_type": "code",
       "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L98",
+      "source_location": "L131",
       "_origin": "ast",
       "id": "packages_shared_src_utils_functions_extract_swagger_response_type_isprimitivetype",
-      "community": 65,
+      "community": 2,
       "norm_label": "isprimitivetype()"
     },
     {
       "label": "inferResponseTypeFromContentType()",
       "file_type": "code",
       "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L134",
+      "source_location": "L167",
       "_origin": "ast",
       "id": "packages_shared_src_utils_functions_extract_swagger_response_type_inferresponsetypefromcontenttype",
-      "community": 65,
+      "community": 2,
       "norm_label": "inferresponsetypefromcontenttype()"
     },
     {
       "label": "getResponseType()",
       "file_type": "code",
       "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L208",
+      "source_location": "L241",
       "_origin": "ast",
       "id": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetype",
-      "community": 26,
+      "community": 2,
       "norm_label": "getresponsetype()"
     },
     {
@@ -8760,7 +8790,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_utils_functions_get_request_body_type",
-      "community": 65,
+      "community": 2,
       "norm_label": "get-request-body-type.ts"
     },
     {
@@ -8770,7 +8800,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "packages_shared_src_utils_functions_get_request_body_type_getrequestbodytype",
-      "community": 60,
+      "community": 156,
       "norm_label": "getrequestbodytype()"
     },
     {
@@ -8810,7 +8840,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_utils_functions_is_url",
-      "community": 57,
+      "community": 159,
       "norm_label": "is-url.ts"
     },
     {
@@ -8840,7 +8870,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_utils_project_utils",
-      "community": 110,
+      "community": 2,
       "norm_label": "project.utils.ts"
     },
     {
@@ -8850,7 +8880,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "packages_shared_src_utils_project_utils_listgeneratedfilenames",
-      "community": 110,
+      "community": 2,
       "norm_label": "listgeneratedfilenames()"
     },
     {
@@ -8870,7 +8900,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "packages_shared_src_utils_string_utils_camelcase",
-      "community": 60,
+      "community": 158,
       "norm_label": "camelcase()"
     },
     {
@@ -8890,7 +8920,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "packages_shared_src_utils_string_utils_pascalcase",
-      "community": 2,
+      "community": 65,
       "norm_label": "pascalcase()"
     },
     {
@@ -8920,7 +8950,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_src_utils_type_utils",
-      "community": 65,
+      "community": 2,
       "norm_label": "type.utils.ts"
     },
     {
@@ -9010,7 +9040,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_tests_extract_paths_test",
-      "community": 65,
+      "community": 78,
       "norm_label": "extract-paths.test.ts"
     },
     {
@@ -9020,17 +9050,17 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_tests_extract_swagger_response_type_test",
-      "community": 65,
+      "community": 2,
       "norm_label": "extract-swagger-response-type.test.ts"
     },
     {
       "label": "config",
       "file_type": "code",
       "source_file": "packages/shared/tests/extract-swagger-response-type.test.ts",
-      "source_location": "L10",
+      "source_location": "L11",
       "_origin": "ast",
       "id": "packages_shared_tests_extract_swagger_response_type_test_config",
-      "community": 65,
+      "community": 2,
       "norm_label": "config"
     },
     {
@@ -9040,7 +9070,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_tests_get_request_body_type_test",
-      "community": 111,
+      "community": 156,
       "norm_label": "get-request-body-type.test.ts"
     },
     {
@@ -9050,7 +9080,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "packages_shared_tests_get_request_body_type_test_config",
-      "community": 111,
+      "community": 156,
       "norm_label": "config"
     },
     {
@@ -9160,7 +9190,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_tests_normalize_test",
-      "community": 65,
+      "community": 78,
       "norm_label": "normalize.test.ts"
     },
     {
@@ -9170,7 +9200,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "packages_shared_tests_normalize_test_spec",
-      "community": 65,
+      "community": 78,
       "norm_label": "spec"
     },
     {
@@ -9180,7 +9210,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_tests_project_utils_test",
-      "community": 110,
+      "community": 2,
       "norm_label": "project.utils.test.ts"
     },
     {
@@ -9190,7 +9220,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "packages_shared_tests_project_utils_test_createproject",
-      "community": 110,
+      "community": 2,
       "norm_label": "createproject()"
     },
     {
@@ -9240,7 +9270,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "packages_shared_tests_swagger_parser_test",
-      "community": 4,
+      "community": 78,
       "norm_label": "swagger-parser.test.ts"
     },
     {
@@ -9250,7 +9280,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "packages_shared_tests_swagger_parser_test_config",
-      "community": 4,
+      "community": 78,
       "norm_label": "config"
     },
     {
@@ -9260,7 +9290,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "packages_shared_tests_swagger_parser_test_v3spec",
-      "community": 4,
+      "community": 78,
       "norm_label": "v3spec"
     },
     {
@@ -9270,7 +9300,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "packages_shared_tests_swagger_parser_test_v2spec",
-      "community": 4,
+      "community": 78,
       "norm_label": "v2spec"
     },
     {
@@ -9280,7 +9310,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "packages_shared_tests_swagger_parser_test_tempdir",
-      "community": 4,
+      "community": 78,
       "norm_label": "tempdir"
     },
     {
@@ -9290,7 +9320,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "packages_shared_tests_swagger_parser_test_writetemp",
-      "community": 4,
+      "community": 78,
       "norm_label": "writetemp()"
     },
     {
@@ -11270,7 +11300,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_configuration",
-      "community": 69,
+      "community": 91,
       "norm_label": "configuration.md"
     },
     {
@@ -11390,7 +11420,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_configuration_client_name",
-      "community": 69,
+      "community": 85,
       "norm_label": "client-name.md"
     },
     {
@@ -11400,7 +11430,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "docs_api_configuration_client_name_clientname",
-      "community": 69,
+      "community": 85,
       "norm_label": "`clientname`"
     },
     {
@@ -11410,7 +11440,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "docs_api_configuration_client_name_usage",
-      "community": 69,
+      "community": 85,
       "norm_label": "usage"
     },
     {
@@ -11420,7 +11450,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "docs_api_configuration_client_name_notes",
-      "community": 69,
+      "community": 85,
       "norm_label": "notes"
     },
     {
@@ -11480,7 +11510,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_configuration_input",
-      "community": 69,
+      "community": 91,
       "norm_label": "input.md"
     },
     {
@@ -11600,7 +11630,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_configuration_options_customize_method_name",
-      "community": 96,
+      "community": 50,
       "norm_label": "customize-method-name.md"
     },
     {
@@ -11610,7 +11640,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "docs_api_configuration_options_customize_method_name_customizemethodname",
-      "community": 96,
+      "community": 50,
       "norm_label": "`customizemethodname`"
     },
     {
@@ -11620,7 +11650,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "docs_api_configuration_options_customize_method_name_usage",
-      "community": 96,
+      "community": 50,
       "norm_label": "usage"
     },
     {
@@ -11630,7 +11660,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "docs_api_configuration_options_customize_method_name_notes",
-      "community": 96,
+      "community": 50,
       "norm_label": "notes"
     },
     {
@@ -11640,7 +11670,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_configuration_options_date_type",
-      "community": 91,
+      "community": 85,
       "norm_label": "date-type.md"
     },
     {
@@ -11702,6 +11732,36 @@
       "id": "docs_api_configuration_options_date_type_notes",
       "community": 85,
       "norm_label": "notes"
+    },
+    {
+      "label": "emit-accept-header.md",
+      "file_type": "document",
+      "source_file": "docs/api/configuration/options/emit-accept-header.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_api_configuration_options_emit_accept_header",
+      "community": 50,
+      "norm_label": "emit-accept-header.md"
+    },
+    {
+      "label": "`emitAcceptHeader`",
+      "file_type": "document",
+      "source_file": "docs/api/configuration/options/emit-accept-header.md",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "docs_api_configuration_options_emit_accept_header_emitacceptheader",
+      "community": 50,
+      "norm_label": "`emitacceptheader`"
+    },
+    {
+      "label": "Usage",
+      "file_type": "document",
+      "source_file": "docs/api/configuration/options/emit-accept-header.md",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "docs_api_configuration_options_emit_accept_header_usage",
+      "community": 50,
+      "norm_label": "usage"
     },
     {
       "label": "enum-style.md",
@@ -11970,7 +12030,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_configuration_options_service_decorator",
-      "community": 50,
+      "community": 42,
       "norm_label": "service-decorator.md"
     },
     {
@@ -11980,7 +12040,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "docs_api_configuration_options_service_decorator_servicedecorator",
-      "community": 50,
+      "community": 101,
       "norm_label": "`servicedecorator`"
     },
     {
@@ -11990,7 +12050,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "docs_api_configuration_options_service_decorator_usage",
-      "community": 50,
+      "community": 101,
       "norm_label": "usage"
     },
     {
@@ -12000,7 +12060,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "docs_api_configuration_options_service_decorator_example",
-      "community": 50,
+      "community": 101,
       "norm_label": "example"
     },
     {
@@ -12010,7 +12070,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "docs_api_configuration_options_service_decorator_notes",
-      "community": 50,
+      "community": 101,
       "norm_label": "notes"
     },
     {
@@ -12070,7 +12130,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_configuration_options_validation",
-      "community": 113,
+      "community": 50,
       "norm_label": "validation.md"
     },
     {
@@ -12080,7 +12140,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "docs_api_configuration_options_validation_validation",
-      "community": 113,
+      "community": 50,
       "norm_label": "`validation`"
     },
     {
@@ -12090,7 +12150,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "docs_api_configuration_options_validation_usage",
-      "community": 113,
+      "community": 50,
       "norm_label": "usage"
     },
     {
@@ -12100,7 +12160,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "docs_api_configuration_options_validation_resources",
-      "community": 113,
+      "community": 50,
       "norm_label": "resources"
     },
     {
@@ -12110,7 +12170,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_configuration_output",
-      "community": 69,
+      "community": 91,
       "norm_label": "output.md"
     },
     {
@@ -12120,7 +12180,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "docs_api_configuration_output_output",
-      "community": 69,
+      "community": 91,
       "norm_label": "`output`"
     },
     {
@@ -12130,7 +12190,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "docs_api_configuration_output_usage",
-      "community": 69,
+      "community": 91,
       "norm_label": "usage"
     },
     {
@@ -12140,7 +12200,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "docs_api_configuration_output_notes",
-      "community": 69,
+      "community": 91,
       "norm_label": "notes"
     },
     {
@@ -12160,7 +12220,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "docs_api_configuration_plugins_plugins",
-      "community": 42,
+      "community": 110,
       "norm_label": "`plugins`"
     },
     {
@@ -12170,7 +12230,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "docs_api_configuration_plugins_usage",
-      "community": 42,
+      "community": 110,
       "norm_label": "usage"
     },
     {
@@ -12180,7 +12240,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "docs_api_configuration_plugins_available_plugins",
-      "community": 42,
+      "community": 110,
       "norm_label": "available plugins"
     },
     {
@@ -12190,7 +12250,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "docs_api_configuration_plugins_notes",
-      "community": 42,
+      "community": 110,
       "norm_label": "notes"
     },
     {
@@ -12280,7 +12340,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_configuration_validate_input",
-      "community": 69,
+      "community": 91,
       "norm_label": "validate-input.md"
     },
     {
@@ -12290,7 +12350,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "docs_api_configuration_validate_input_validateinput",
-      "community": 69,
+      "community": 68,
       "norm_label": "`validateinput`"
     },
     {
@@ -12300,7 +12360,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "docs_api_configuration_validate_input_usage",
-      "community": 69,
+      "community": 68,
       "norm_label": "usage"
     },
     {
@@ -12310,7 +12370,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "docs_api_configuration_validate_input_parameters",
-      "community": 69,
+      "community": 68,
       "norm_label": "parameters"
     },
     {
@@ -12320,7 +12380,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "docs_api_configuration_validate_input_return_value",
-      "community": 69,
+      "community": 68,
       "norm_label": "return value"
     },
     {
@@ -12330,7 +12390,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "docs_api_configuration_validate_input_notes",
-      "community": 69,
+      "community": 68,
       "norm_label": "notes"
     },
     {
@@ -12340,7 +12400,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_providers",
-      "community": 91,
+      "community": 85,
       "norm_label": "providers.md"
     },
     {
@@ -12490,7 +12550,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_utilities_date_transformer",
-      "community": 91,
+      "community": 24,
       "norm_label": "date-transformer.md"
     },
     {
@@ -12500,7 +12560,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "docs_api_utilities_date_transformer_date_transformer",
-      "community": 92,
+      "community": 24,
       "norm_label": "date transformer"
     },
     {
@@ -12510,7 +12570,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "docs_api_utilities_date_transformer_usage",
-      "community": 92,
+      "community": 24,
       "norm_label": "usage"
     },
     {
@@ -12520,7 +12580,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "docs_api_utilities_date_transformer_manual_setup",
-      "community": 92,
+      "community": 24,
       "norm_label": "manual setup"
     },
     {
@@ -12530,7 +12590,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "docs_api_utilities_date_transformer_generated_source",
-      "community": 92,
+      "community": 24,
       "norm_label": "generated source"
     },
     {
@@ -12540,7 +12600,7 @@
       "source_location": "L93",
       "_origin": "ast",
       "id": "docs_api_utilities_date_transformer_recognized_formats",
-      "community": 92,
+      "community": 24,
       "norm_label": "recognized formats"
     },
     {
@@ -12550,7 +12610,7 @@
       "source_location": "L110",
       "_origin": "ast",
       "id": "docs_api_utilities_date_transformer_customizing_the_regex",
-      "community": 92,
+      "community": 24,
       "norm_label": "customizing the regex"
     },
     {
@@ -13120,7 +13180,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_guide_date_handling",
-      "community": 91,
+      "community": 24,
       "norm_label": "date-handling.md"
     },
     {
@@ -13400,7 +13460,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_guide_generated_code",
-      "community": 91,
+      "community": 42,
       "norm_label": "generated-code.md"
     },
     {
@@ -13690,7 +13750,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_guide_http_resource",
-      "community": 69,
+      "community": 91,
       "norm_label": "http-resource.md"
     },
     {
@@ -13990,7 +14050,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "docs_guide_plugin_authoring_plugin_authoring",
-      "community": 42,
+      "community": 113,
       "norm_label": "plugin authoring"
     },
     {
@@ -14000,7 +14060,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "docs_guide_plugin_authoring_the_contract",
-      "community": 42,
+      "community": 113,
       "norm_label": "the contract"
     },
     {
@@ -14010,7 +14070,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "docs_guide_plugin_authoring_what_the_context_provides",
-      "community": 42,
+      "community": 113,
       "norm_label": "what the context provides"
     },
     {
@@ -14020,7 +14080,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "docs_guide_plugin_authoring_rules_of_engagement",
-      "community": 42,
+      "community": 113,
       "norm_label": "rules of engagement"
     },
     {
@@ -15693,7 +15753,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/.vitepress/config.ts",
-      "source_location": "L380",
+      "source_location": "L384",
       "weight": 1.0,
       "source": "docs_vitepress_config",
       "target": "docs_vitepress_config_buildend",
@@ -15795,7 +15855,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "docs/.vitepress/config.ts",
-      "source_location": "L418",
+      "source_location": "L422",
       "weight": 1.0,
       "source": "docs_vitepress_config_buildend",
       "target": "docs_vitepress_config_pageurl",
@@ -15818,7 +15878,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "docs/.vitepress/config.ts",
-      "source_location": "L398",
+      "source_location": "L402",
       "weight": 1.0,
       "source": "docs_vitepress_config_buildend",
       "target": "docs_vitepress_config_llm_excluded"
@@ -15839,7 +15899,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "docs/.vitepress/config.ts",
-      "source_location": "L399",
+      "source_location": "L403",
       "weight": 1.0,
       "source": "docs_vitepress_config_buildend",
       "target": "docs_vitepress_config_sectionrank",
@@ -15850,7 +15910,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "docs/.vitepress/config.ts",
-      "source_location": "L397",
+      "source_location": "L401",
       "weight": 1.0,
       "source": "docs_vitepress_config_buildend",
       "target": "docs_vitepress_config_walkmarkdown",
@@ -15861,7 +15921,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "docs/.vitepress/config.ts",
-      "source_location": "L411",
+      "source_location": "L415",
       "weight": 1.0,
       "source": "docs_vitepress_config_buildend",
       "target": "docs_vitepress_config_resolveincludes",
@@ -15872,7 +15932,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "docs/.vitepress/config.ts",
-      "source_location": "L418",
+      "source_location": "L422",
       "weight": 1.0,
       "source": "docs_vitepress_config_buildend",
       "target": "docs_vitepress_config_stripfrontmatter",
@@ -18254,7 +18314,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/ng-openapi/src/lib/core/config-validation.ts",
-      "source_location": "L141",
+      "source_location": "L146",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_core_config_validation_validategeneratorconfig",
       "target": "packages_ng_openapi_src_lib_core_config_validation_response_types"
@@ -20018,7 +20078,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L113",
+      "source_location": "L114",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator",
       "target": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatehttprequest",
@@ -20038,7 +20098,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L39",
+      "source_location": "L40",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator",
       "target": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatemultipartformdata",
@@ -20048,7 +20108,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L80",
+      "source_location": "L81",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator",
       "target": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generateurlencodedformdata",
@@ -20081,7 +20141,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L33",
+      "source_location": "L34",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatemethodbody",
       "target": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatehttprequest",
@@ -20092,7 +20152,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L31",
+      "source_location": "L32",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatemethodbody",
       "target": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatemultipartformdata",
@@ -20103,7 +20163,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L32",
+      "source_location": "L33",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatemethodbody",
       "target": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generateurlencodedformdata",
@@ -20158,7 +20218,7 @@
       "context": "parameter_type",
       "confidence": "EXTRACTED",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L39",
+      "source_location": "L40",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatemultipartformdata",
       "target": "packages_shared_src_model_operation_model_normalizedoperation",
@@ -20169,7 +20229,7 @@
       "context": "parameter_type",
       "confidence": "EXTRACTED",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L80",
+      "source_location": "L81",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generateurlencodedformdata",
       "target": "packages_shared_src_model_operation_model_normalizedoperation",
@@ -20181,7 +20241,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L147",
+      "source_location": "L148",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatehttprequest",
       "target": "packages_shared_src_emit_response_type_emit_emitresponsetypeoption"
@@ -20192,7 +20252,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L154",
+      "source_location": "L155",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatehttprequest",
       "target": "packages_shared_src_emit_response_type_emit_joinrequestoptionentries"
@@ -20202,7 +20262,7 @@
       "context": "parameter_type",
       "confidence": "EXTRACTED",
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L113",
+      "source_location": "L114",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatehttprequest",
       "target": "packages_shared_src_model_operation_model_normalizedoperation",
@@ -20214,7 +20274,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L123",
+      "source_location": "L124",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatehttprequest",
       "target": "packages_shared_src_utils_functions_get_request_body_type_getrequestbodytype"
@@ -20225,7 +20285,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L124",
+      "source_location": "L125",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatehttprequest",
       "target": "packages_shared_src_utils_functions_is_data_type_interface_isdatatypeinterface"
@@ -20236,7 +20296,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts",
-      "source_location": "L125",
+      "source_location": "L126",
       "weight": 1.0,
       "source": "packages_ng_openapi_src_lib_generators_service_service_method_service_method_body_generator_servicemethodbodygenerator_generatehttprequest",
       "target": "packages_shared_src_utils_string_utils_camelcase"
@@ -25763,7 +25823,17 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L28",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator",
+      "target": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_defaultheaders",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
+      "source_location": "L29",
       "weight": 1.0,
       "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator",
       "target": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generatedefaultheaders",
@@ -25773,7 +25843,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L64",
+      "source_location": "L74",
       "weight": 1.0,
       "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator",
       "target": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generatehttpresource",
@@ -25793,7 +25863,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L36",
+      "source_location": "L46",
       "weight": 1.0,
       "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator",
       "target": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generaterequestoptions",
@@ -25858,19 +25928,63 @@
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
+      "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generatedefaultheaders",
+      "target": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_defaultheaders",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L33",
+      "source_location": "L34",
       "weight": 1.0,
       "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generatedefaultheaders",
       "target": "packages_shared_src_emit_headers_emit_emitdefaultheadersmerge"
+    },
+    {
+      "relation": "references",
+      "context": "parameter_type",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generatedefaultheaders",
+      "target": "packages_shared_src_model_operation_model_normalizedoperation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "context": "parameter_type",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_defaultheaders",
+      "target": "packages_shared_src_model_operation_model_normalizedoperation",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L65",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generaterequestoptions",
+      "target": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_defaultheaders",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
+      "source_location": "L75",
       "weight": 1.0,
       "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generatehttpresource",
       "target": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generaterequestoptions",
@@ -25882,7 +25996,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L57",
+      "source_location": "L67",
       "weight": 1.0,
       "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generaterequestoptions",
       "target": "packages_shared_src_emit_response_type_emit_joinrequestoptionentries"
@@ -25893,7 +26007,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L38",
+      "source_location": "L48",
       "weight": 1.0,
       "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generaterequestoptions",
       "target": "packages_shared_src_emit_url_emit_emiturlexpression"
@@ -25904,7 +26018,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L38",
+      "source_location": "L48",
       "weight": 1.0,
       "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generaterequestoptions",
       "target": "packages_shared_src_emit_url_emit_signalawareparamvalue"
@@ -25914,7 +26028,7 @@
       "context": "parameter_type",
       "confidence": "EXTRACTED",
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L36",
+      "source_location": "L46",
       "weight": 1.0,
       "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generaterequestoptions",
       "target": "packages_shared_src_model_operation_model_normalizedoperation",
@@ -25926,7 +26040,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L66",
+      "source_location": "L76",
       "weight": 1.0,
       "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generatehttpresource",
       "target": "packages_shared_src_emit_query_params_emit_emitsignalawarequeryparams"
@@ -25936,7 +26050,7 @@
       "context": "parameter_type",
       "confidence": "EXTRACTED",
       "source_file": "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts",
-      "source_location": "L64",
+      "source_location": "L74",
       "weight": 1.0,
       "source": "packages_plugins_http_resource_src_lib_http_resource_method_http_resource_method_body_generator_httpresourcemethodbodygenerator_generatehttpresource",
       "target": "packages_shared_src_model_operation_model_normalizedoperation",
@@ -30522,7 +30636,7 @@
       "context": "export",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/index.ts",
-      "source_location": "L90",
+      "source_location": "L92",
       "weight": 1.0,
       "source": "packages_shared_src_index",
       "target": "packages_shared_src_config_index",
@@ -30598,17 +30712,17 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L188",
+      "source_location": "L192",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
-      "target": "packages_shared_src_core_normalize_determineresponsetype",
+      "target": "packages_shared_src_core_normalize_determineresponseinfo",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L140",
+      "source_location": "L141",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_core_normalize_normalizecontentschemas",
@@ -30618,7 +30732,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L152",
+      "source_location": "L153",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_core_normalize_normalizeoperation",
@@ -30628,7 +30742,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L120",
+      "source_location": "L121",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_core_normalize_normalizeoperationschemas",
@@ -30638,7 +30752,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L54",
+      "source_location": "L55",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_core_normalize_normalizeschema",
@@ -30648,7 +30762,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L18",
+      "source_location": "L19",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_core_normalize_normalizespec",
@@ -30658,7 +30772,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L179",
+      "source_location": "L183",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_core_normalize_resolvebodyschema",
@@ -30668,7 +30782,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L10",
+      "source_location": "L11",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_core_normalize_resolveref",
@@ -30679,7 +30793,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L7",
+      "source_location": "L8",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_model_operation_model",
@@ -30690,21 +30804,10 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L7",
+      "source_location": "L8",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_model_operation_model_normalizedoperation",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports",
-      "context": "import",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L7",
-      "weight": 1.0,
-      "source": "packages_shared_src_core_normalize",
-      "target": "packages_shared_src_model_operation_model_responsekind",
       "confidence_score": 1.0
     },
     {
@@ -30712,7 +30815,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L8",
+      "source_location": "L9",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_model_spec_model",
@@ -30723,7 +30826,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L8",
+      "source_location": "L9",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_model_spec_model_normalizedspec",
@@ -30734,7 +30837,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L6",
+      "source_location": "L7",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_types_swagger_types",
@@ -30745,7 +30848,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L6",
+      "source_location": "L7",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_types_swagger_types_pathinfo",
@@ -30756,7 +30859,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L6",
+      "source_location": "L7",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_types_swagger_types_requestbody",
@@ -30767,7 +30870,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L6",
+      "source_location": "L7",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_types_swagger_types_swaggerdefinition",
@@ -30778,7 +30881,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L6",
+      "source_location": "L7",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_types_swagger_types_swaggerspec",
@@ -30833,7 +30936,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L5",
+      "source_location": "L6",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
       "target": "packages_shared_src_utils_functions_extract_swagger_response_type",
@@ -30847,7 +30950,18 @@
       "source_location": "L5",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize",
-      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetypefromresponse",
+      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponseinfofromresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/shared/src/core/normalize.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "packages_shared_src_core_normalize",
+      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_responsetypeinfo",
       "confidence_score": 1.0
     },
     {
@@ -30866,7 +30980,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L36",
+      "source_location": "L37",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize_normalizespec",
       "target": "packages_shared_src_core_normalize_normalizeoperation",
@@ -30877,7 +30991,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L36",
+      "source_location": "L37",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize_normalizespec",
       "target": "packages_shared_src_core_normalize_normalizeoperationschemas",
@@ -30888,7 +31002,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L21",
+      "source_location": "L22",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize_normalizespec",
       "target": "packages_shared_src_core_normalize_normalizeschema",
@@ -30900,7 +31014,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L35",
+      "source_location": "L36",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize_normalizespec",
       "target": "packages_shared_src_utils_functions_extract_paths_extractpaths"
@@ -30943,7 +31057,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L147",
+      "source_location": "L148",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize_normalizecontentschemas",
       "target": "packages_shared_src_core_normalize_normalizeschema",
@@ -30954,7 +31068,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L124",
+      "source_location": "L125",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize_normalizeoperationschemas",
       "target": "packages_shared_src_core_normalize_normalizeschema",
@@ -30976,7 +31090,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L127",
+      "source_location": "L128",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize_normalizeoperationschemas",
       "target": "packages_shared_src_core_normalize_normalizecontentschemas",
@@ -30987,10 +31101,10 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L175",
+      "source_location": "L165",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize_normalizeoperation",
-      "target": "packages_shared_src_core_normalize_determineresponsetype",
+      "target": "packages_shared_src_core_normalize_determineresponseinfo",
       "confidence_score": 1.0
     },
     {
@@ -30998,7 +31112,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L158",
+      "source_location": "L159",
       "weight": 1.0,
       "source": "packages_shared_src_core_normalize_normalizeoperation",
       "target": "packages_shared_src_core_normalize_resolvebodyschema",
@@ -31009,10 +31123,10 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/core/normalize.ts",
-      "source_location": "L195",
+      "source_location": "L199",
       "weight": 1.0,
-      "source": "packages_shared_src_core_normalize_determineresponsetype",
-      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetypefromresponse",
+      "source": "packages_shared_src_core_normalize_determineresponseinfo",
+      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponseinfofromresponse",
       "confidence_score": 1.0
     },
     {
@@ -31718,7 +31832,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/emit/headers.emit.ts",
-      "source_location": "L79",
+      "source_location": "L89",
       "weight": 1.0,
       "source": "packages_shared_src_emit_headers_emit",
       "target": "packages_shared_src_emit_headers_emit_emitdefaultheaderguards",
@@ -31728,7 +31842,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/emit/headers.emit.ts",
-      "source_location": "L64",
+      "source_location": "L74",
       "weight": 1.0,
       "source": "packages_shared_src_emit_headers_emit",
       "target": "packages_shared_src_emit_headers_emit_emitdefaultheadersmerge",
@@ -31738,7 +31852,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/emit/headers.emit.ts",
-      "source_location": "L19",
+      "source_location": "L21",
       "weight": 1.0,
       "source": "packages_shared_src_emit_headers_emit",
       "target": "packages_shared_src_emit_headers_emit_emitheaders",
@@ -31781,7 +31895,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/emit/headers.emit.ts",
-      "source_location": "L33",
+      "source_location": "L35",
       "weight": 1.0,
       "source": "packages_shared_src_emit_headers_emit_emitheaders",
       "target": "packages_shared_src_emit_headers_emit_emitdefaultheaderguards",
@@ -31814,7 +31928,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/emit/headers.emit.ts",
-      "source_location": "L73",
+      "source_location": "L83",
       "weight": 1.0,
       "source": "packages_shared_src_emit_headers_emit_emitdefaultheadersmerge",
       "target": "packages_shared_src_emit_headers_emit_emitdefaultheaderguards",
@@ -33066,7 +33180,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/types/config.types.ts",
-      "source_location": "L123",
+      "source_location": "L128",
       "weight": 1.0,
       "source": "packages_shared_src_types_config_types",
       "target": "packages_shared_src_types_config_types_methodgenoptions",
@@ -33096,7 +33210,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/types/config.types.ts",
-      "source_location": "L139",
+      "source_location": "L145",
       "weight": 1.0,
       "source": "packages_shared_src_types_config_types",
       "target": "packages_shared_src_types_config_types_ngopenapiclientconfig",
@@ -33106,7 +33220,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/types/config.types.ts",
-      "source_location": "L108",
+      "source_location": "L113",
       "weight": 1.0,
       "source": "packages_shared_src_types_config_types",
       "target": "packages_shared_src_types_config_types_typegenoptions",
@@ -33116,7 +33230,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/types/config.types.ts",
-      "source_location": "L98",
+      "source_location": "L103",
       "weight": 1.0,
       "source": "packages_shared_src_types_config_types",
       "target": "packages_shared_src_types_config_types_typemappingconfig",
@@ -33237,7 +33351,7 @@
       "context": "field",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/types/config.types.ts",
-      "source_location": "L86",
+      "source_location": "L91",
       "weight": 1.0,
       "source": "packages_shared_src_types_config_types_generatorconfig",
       "target": "packages_shared_src_types_plugin_types_iplugingeneratorclass",
@@ -34410,7 +34524,17 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L208",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "packages_shared_src_utils_functions_extract_swagger_response_type",
+      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponseinfofromresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
+      "source_location": "L241",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_extract_swagger_response_type",
       "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetype",
@@ -34420,7 +34544,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L11",
+      "source_location": "L23",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_extract_swagger_response_type",
       "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetypefromresponse",
@@ -34430,7 +34554,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L134",
+      "source_location": "L167",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_extract_swagger_response_type",
       "target": "packages_shared_src_utils_functions_extract_swagger_response_type_inferresponsetypefromcontenttype",
@@ -34440,10 +34564,20 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L98",
+      "source_location": "L131",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_extract_swagger_response_type",
       "target": "packages_shared_src_utils_functions_extract_swagger_response_type_isprimitivetype",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "packages_shared_src_utils_functions_extract_swagger_response_type",
+      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_responsetypeinfo",
       "confidence_score": 1.0
     },
     {
@@ -34480,11 +34614,22 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "re_exports",
+      "context": "re-export",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/shared/src/utils/functions/index.ts",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "packages_shared_src_utils_functions_index",
+      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_responsetypeinfo",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L209",
+      "source_location": "L242",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetype",
       "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetypefromresponse",
@@ -34495,21 +34640,10 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L66",
+      "source_location": "L27",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetypefromresponse",
-      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_inferresponsetypefromcontenttype",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L65",
-      "weight": 1.0,
-      "source": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetypefromresponse",
-      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_isprimitivetype",
+      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponseinfofromresponse",
       "confidence_score": 1.0
     },
     {
@@ -34532,6 +34666,50 @@
       "weight": 1.0,
       "source": "packages_shared_tests_extract_swagger_response_type_test",
       "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetypefromresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
+      "source_location": "L91",
+      "weight": 1.0,
+      "source": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponseinfofromresponse",
+      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_inferresponsetypefromcontenttype",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
+      "source_location": "L90",
+      "weight": 1.0,
+      "source": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponseinfofromresponse",
+      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_isprimitivetype",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "re_exports",
+      "context": "re-export",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/shared/src/utils/functions/index.ts",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "packages_shared_src_utils_functions_index",
+      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponseinfofromresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/shared/tests/extract-swagger-response-type.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "packages_shared_tests_extract_swagger_response_type_test",
+      "target": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponseinfofromresponse",
       "confidence_score": 1.0
     },
     {
@@ -34584,7 +34762,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "packages/shared/src/utils/functions/extract-swagger-response-type.ts",
-      "source_location": "L216",
+      "source_location": "L249",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_extract_swagger_response_type_getresponsetype",
       "target": "packages_shared_src_utils_type_utils_gettypescripttype"
@@ -34648,7 +34826,7 @@
       "context": "export",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/index.ts",
-      "source_location": "L15",
+      "source_location": "L17",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_index",
       "target": "packages_shared_src_utils_functions_generate_parse_request_type_params",
@@ -34670,7 +34848,7 @@
       "context": "re-export",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/index.ts",
-      "source_location": "L15",
+      "source_location": "L17",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_index",
       "target": "packages_shared_src_utils_functions_generate_parse_request_type_params_generateparserequesttypeparams",
@@ -34724,7 +34902,7 @@
       "context": "export",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/index.ts",
-      "source_location": "L13",
+      "source_location": "L15",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_index",
       "target": "packages_shared_src_utils_functions_get_request_body_type",
@@ -34746,7 +34924,7 @@
       "context": "re-export",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/index.ts",
-      "source_location": "L13",
+      "source_location": "L15",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_index",
       "target": "packages_shared_src_utils_functions_get_request_body_type_getrequestbodytype",
@@ -34768,7 +34946,7 @@
       "context": "export",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/index.ts",
-      "source_location": "L14",
+      "source_location": "L16",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_index",
       "target": "packages_shared_src_utils_functions_is_data_type_interface",
@@ -34779,7 +34957,7 @@
       "context": "re-export",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/index.ts",
-      "source_location": "L14",
+      "source_location": "L16",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_index",
       "target": "packages_shared_src_utils_functions_is_data_type_interface_isdatatypeinterface",
@@ -34790,7 +34968,7 @@
       "context": "export",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/index.ts",
-      "source_location": "L16",
+      "source_location": "L18",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_index",
       "target": "packages_shared_src_utils_functions_is_url",
@@ -34801,7 +34979,7 @@
       "context": "re-export",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/src/utils/functions/index.ts",
-      "source_location": "L16",
+      "source_location": "L18",
       "weight": 1.0,
       "source": "packages_shared_src_utils_functions_index",
       "target": "packages_shared_src_utils_functions_is_url_isurl",
@@ -35227,7 +35405,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/shared/tests/extract-swagger-response-type.test.ts",
-      "source_location": "L10",
+      "source_location": "L11",
       "weight": 1.0,
       "source": "packages_shared_tests_extract_swagger_response_type_test",
       "target": "packages_shared_tests_extract_swagger_response_type_test_config",
@@ -37564,7 +37742,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/configuration/options.md",
-      "source_location": "L50",
+      "source_location": "L51",
       "weight": 1.0,
       "source": "docs_api_configuration_options",
       "target": "docs_api_configuration_options_customize_method_name",
@@ -37578,6 +37756,16 @@
       "weight": 1.0,
       "source": "docs_api_configuration_options",
       "target": "docs_api_configuration_options_date_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/configuration/options.md",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "docs_api_configuration_options",
+      "target": "docs_api_configuration_options_emit_accept_header",
       "confidence_score": 1.0
     },
     {
@@ -37614,7 +37802,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/configuration/options.md",
-      "source_location": "L53",
+      "source_location": "L54",
       "weight": 1.0,
       "source": "docs_api_configuration_options",
       "target": "docs_api_configuration_options_naming",
@@ -37634,7 +37822,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/configuration/options.md",
-      "source_location": "L49",
+      "source_location": "L50",
       "weight": 1.0,
       "source": "docs_api_configuration_options",
       "target": "docs_api_configuration_options_response_type_mapping",
@@ -37644,7 +37832,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/configuration/options.md",
-      "source_location": "L52",
+      "source_location": "L53",
       "weight": 1.0,
       "source": "docs_api_configuration_options",
       "target": "docs_api_configuration_options_service_decorator",
@@ -37654,7 +37842,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/configuration/options.md",
-      "source_location": "L51",
+      "source_location": "L52",
       "weight": 1.0,
       "source": "docs_api_configuration_options",
       "target": "docs_api_configuration_options_use_single_request_parameter",
@@ -37698,6 +37886,16 @@
       "weight": 1.0,
       "source": "docs_api_configuration_options_custom_headers",
       "target": "docs_api_configuration_options_custom_headers_customheaders",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/configuration/options/emit-accept-header.md",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "docs_api_configuration_options_emit_accept_header",
+      "target": "docs_api_configuration_options_custom_headers",
       "confidence_score": 1.0
     },
     {
@@ -37838,6 +38036,26 @@
       "weight": 1.0,
       "source": "docs_api_configuration_options_date_type_supported_options",
       "target": "docs_api_configuration_options_date_type_string",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/configuration/options/emit-accept-header.md",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "docs_api_configuration_options_emit_accept_header",
+      "target": "docs_api_configuration_options_emit_accept_header_emitacceptheader",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/configuration/options/emit-accept-header.md",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "docs_api_configuration_options_emit_accept_header_emitacceptheader",
+      "target": "docs_api_configuration_options_emit_accept_header_usage",
       "confidence_score": 1.0
     },
     {
@@ -41240,5 +41458,5 @@
       "source_file": ".github/workflows/release.yml"
     }
   ],
-  "built_at_commit": "d5a26e8ddd3384923edf3ca6e89c0cadd618e3b2"
+  "built_at_commit": "db3670ff5b35ac4c36827998ae0876e01c32f5aa"
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -20,8 +20,8 @@
     "semantic_hash": "f1654637abe04c1cff0d00835c879c4d"
   },
   "docs/.vitepress/config.ts": {
-    "mtime": 1783327986.7570932,
-    "ast_hash": "9b65295bf8d397dd5e34269806386544",
+    "mtime": 1783331257.8604553,
+    "ast_hash": "d366d65daaf2854eb5b43251691c8db0",
     "semantic_hash": ""
   },
   "docs/.vitepress/theme/index.ts": {
@@ -75,7 +75,7 @@
     "semantic_hash": ""
   },
   "packages/ng-openapi/src/lib/core/generator.ts": {
-    "mtime": 1783327889.848529,
+    "mtime": 1783328453.3769898,
     "ast_hash": "a8a41e4d0533016db5fbac66ac13293d",
     "semantic_hash": ""
   },
@@ -100,7 +100,7 @@
     "semantic_hash": ""
   },
   "packages/ng-openapi/src/lib/generators/service/service-index.generator.ts": {
-    "mtime": 1783327889.848529,
+    "mtime": 1783328453.3779898,
     "ast_hash": "340b3f25043519cefb35111c5179fce3",
     "semantic_hash": ""
   },
@@ -115,8 +115,8 @@
     "semantic_hash": "7f2924da3ea9420febe3bbc5425803d6"
   },
   "packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts": {
-    "mtime": 1783296715.1910765,
-    "ast_hash": "5c55c5d2db9375c93b451ff13047e428",
+    "mtime": 1783330986.7140331,
+    "ast_hash": "c7460b5d454d3163bce4b75aedb88559",
     "semantic_hash": ""
   },
   "packages/ng-openapi/src/lib/generators/service/service-method/service-method-overloads.generator.ts": {
@@ -135,7 +135,7 @@
     "semantic_hash": "19db8b64ee57d70c3612622298e8b297"
   },
   "packages/ng-openapi/src/lib/generators/service/service.generator.ts": {
-    "mtime": 1783327889.8495443,
+    "mtime": 1783328453.3779898,
     "ast_hash": "715178fa1372cc6c7a7aa120d1cf0ec9",
     "semantic_hash": ""
   },
@@ -185,7 +185,7 @@
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/compile-check.test.ts": {
-    "mtime": 1783327889.8685646,
+    "mtime": 1783328453.4285016,
     "ast_hash": "b2418adf09ab4504ae9c2189f99c7e71",
     "semantic_hash": ""
   },
@@ -225,7 +225,7 @@
     "semantic_hash": "6a69ff64986cfd6072638bb051863521"
   },
   "packages/plugins/http-resource/src/lib/http-resource-index.generator.ts": {
-    "mtime": 1783327889.8695507,
+    "mtime": 1783328453.4305015,
     "ast_hash": "6f79b1743520e5085a3882380da66ccd",
     "semantic_hash": ""
   },
@@ -235,8 +235,8 @@
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts": {
-    "mtime": 1783296715.3492095,
-    "ast_hash": "be70e2195b792f2b9c3d0d258b10110b",
+    "mtime": 1783330977.9832296,
+    "ast_hash": "dc454ab6524641737eb6c5cc96b40958",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-params.generator.ts": {
@@ -250,7 +250,7 @@
     "semantic_hash": "31d5de8637a81564582bd255e7a8354f"
   },
   "packages/plugins/http-resource/src/lib/http-resource.generator.ts": {
-    "mtime": 1783327889.8705466,
+    "mtime": 1783328453.4315026,
     "ast_hash": "e910c7cd8029480ce2d36c1c0b26ff45",
     "semantic_hash": ""
   },
@@ -260,7 +260,7 @@
     "semantic_hash": "d75dea9d6eedb8c3fad017006209de9d"
   },
   "packages/plugins/http-resource/tests/compile-check.test.ts": {
-    "mtime": 1783327889.8935454,
+    "mtime": 1783328453.4860177,
     "ast_hash": "decff365bab5fcd3e99c69125a52943a",
     "semantic_hash": ""
   },
@@ -390,13 +390,13 @@
     "semantic_hash": ""
   },
   "packages/shared/src/index.ts": {
-    "mtime": 1783327889.8955462,
-    "ast_hash": "6a1583bb8422cdabea497c6d96dc3f36",
+    "mtime": 1783330890.9832306,
+    "ast_hash": "1b4af2de8c67a184dd0a5e185990dc0a",
     "semantic_hash": ""
   },
   "packages/shared/src/types/config.types.ts": {
-    "mtime": 1783327984.4077075,
-    "ast_hash": "8a20cdb46bf81107af713d5703ebab87",
+    "mtime": 1783330939.383991,
+    "ast_hash": "46fd51d45385295880aa6e5369e7a14d",
     "semantic_hash": ""
   },
   "packages/shared/src/types/generator.types.ts": {
@@ -405,7 +405,7 @@
     "semantic_hash": ""
   },
   "packages/shared/src/types/index.ts": {
-    "mtime": 1783327889.8965304,
+    "mtime": 1783328453.4910178,
     "ast_hash": "0c28b4539ffdc8de8fdc415202e8daf9",
     "semantic_hash": ""
   },
@@ -435,8 +435,8 @@
     "semantic_hash": ""
   },
   "packages/shared/src/utils/functions/extract-swagger-response-type.ts": {
-    "mtime": 1783299374.7835102,
-    "ast_hash": "0fa33f02df3a7638a0b2d73ddb6fa96e",
+    "mtime": 1783330820.3685918,
+    "ast_hash": "47d791bddc6b1a93442d101dd4af1afb",
     "semantic_hash": ""
   },
   "packages/shared/src/utils/functions/generate-parse-request-type-params.ts": {
@@ -450,8 +450,8 @@
     "semantic_hash": ""
   },
   "packages/shared/src/utils/functions/index.ts": {
-    "mtime": 1783327889.8975463,
-    "ast_hash": "336c97af39ac205bb0cbcba1a24400fb",
+    "mtime": 1783330867.3727076,
+    "ast_hash": "4b605b8623ee2424a739992be6389f8a",
     "semantic_hash": ""
   },
   "packages/shared/src/utils/functions/is-data-type-interface.ts": {
@@ -465,8 +465,8 @@
     "semantic_hash": "bae95882ce0cb919d8e781ee775efc27"
   },
   "packages/shared/src/utils/index.ts": {
-    "mtime": 1783327889.8975463,
-    "ast_hash": "9bf468918c8f1cc70307d4724f36efda",
+    "mtime": 1783330887.9336596,
+    "ast_hash": "d1d3fe8ec4ea2453987ced43a3f15433",
     "semantic_hash": ""
   },
   "packages/shared/src/utils/string.utils.ts": {
@@ -475,7 +475,7 @@
     "semantic_hash": ""
   },
   "packages/shared/src/utils/type.utils.ts": {
-    "mtime": 1783327889.8975463,
+    "mtime": 1783328453.4930198,
     "ast_hash": "5470ab710893d599468f87cbfca2138a",
     "semantic_hash": ""
   },
@@ -635,8 +635,8 @@
     "semantic_hash": ""
   },
   "docs/api/configuration/options.md": {
-    "mtime": 1783327990.156859,
-    "ast_hash": "d5a5b4c8c27ae1fed4b99af79b9d044d",
+    "mtime": 1783331241.1056519,
+    "ast_hash": "aecaca90ea89f497fc1a2e238493975a",
     "semantic_hash": ""
   },
   "docs/api/configuration/options/custom-headers.md": {
@@ -695,7 +695,7 @@
     "semantic_hash": ""
   },
   "docs/api/configuration/plugins/http-resource.md": {
-    "mtime": 1783327937.8065064,
+    "mtime": 1783328453.3639882,
     "ast_hash": "19e099c1e6f8820f4fbafdde2a8e6d6a",
     "semantic_hash": ""
   },
@@ -780,7 +780,7 @@
     "semantic_hash": ""
   },
   "docs/guide/generated-code.md": {
-    "mtime": 1783327944.2221549,
+    "mtime": 1783328453.3650103,
     "ast_hash": "6b739dbc5a46a17db246142c77857a41",
     "semantic_hash": ""
   },
@@ -855,12 +855,12 @@
     "semantic_hash": "e40f899c2c2ce01d8f70ed168c596faf"
   },
   "packages/ng-openapi/tests/golden.test.ts": {
-    "mtime": 1783327928.8487084,
+    "mtime": 1783328453.4295044,
     "ast_hash": "5db9740f28a058400baabece949832da",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/tests/golden.test.ts": {
-    "mtime": 1783327934.979126,
+    "mtime": 1783328453.487019,
     "ast_hash": "45d4e86c65038ab59913064594b0b9d2",
     "semantic_hash": ""
   },
@@ -875,8 +875,8 @@
     "semantic_hash": ""
   },
   "packages/shared/tests/extract-swagger-response-type.test.ts": {
-    "mtime": 1783296715.4913003,
-    "ast_hash": "6740b5321258d2e1ba1655deea360277",
+    "mtime": 1783331028.4749494,
+    "ast_hash": "a4deed9a7743a55295616b28cf2ae474",
     "semantic_hash": ""
   },
   "packages/shared/tests/get-request-body-type.test.ts": {
@@ -910,8 +910,8 @@
     "semantic_hash": ""
   },
   "packages/testing/fixtures/specs/edge-cases.json": {
-    "mtime": 1783296715.497301,
-    "ast_hash": "8a5c339cfff5fb84ff8a81c45765ec24",
+    "mtime": 1783331070.2720673,
+    "ast_hash": "c1f5cd1768b9f4b75896a350b6241746",
     "semantic_hash": ""
   },
   "packages/testing/fixtures/specs/openapi-3.0.json": {
@@ -1105,18 +1105,18 @@
     "semantic_hash": ""
   },
   "packages/ng-openapi/src/lib/core/config-validation.ts": {
-    "mtime": 1783327889.847545,
-    "ast_hash": "f9d28412bb840529f5f8ee303e59cfc8",
+    "mtime": 1783330941.3018494,
+    "ast_hash": "5e6e3afc471f38e92629d73250fb0fd9",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/config-validation.test.ts": {
-    "mtime": 1783327889.8685646,
+    "mtime": 1783328453.4295044,
     "ast_hash": "221f4c6329142c0ed5220e9698d18bed",
     "semantic_hash": ""
   },
   "packages/shared/src/core/normalize.ts": {
-    "mtime": 1783296715.4663057,
-    "ast_hash": "82b0c2bfa249e079c96f05eb77982c9e",
+    "mtime": 1783330844.7205029,
+    "ast_hash": "84566bd47e34090b17aac127845d6184",
     "semantic_hash": ""
   },
   "packages/shared/src/core/spec-format.ts": {
@@ -1135,8 +1135,8 @@
     "semantic_hash": ""
   },
   "packages/shared/src/model/operation.model.ts": {
-    "mtime": 1783296715.4733057,
-    "ast_hash": "a9d29822794394ccaf5ab48b1aa63428",
+    "mtime": 1783330827.6470642,
+    "ast_hash": "e2144c11f7619bae5b981243b7190f7c",
     "semantic_hash": ""
   },
   "packages/shared/src/model/spec.model.ts": {
@@ -1145,8 +1145,8 @@
     "semantic_hash": ""
   },
   "packages/shared/tests/normalize.test.ts": {
-    "mtime": 1783296715.4932983,
-    "ast_hash": "9d83eec41a5a347ca7b0e68bf3376f46",
+    "mtime": 1783331032.9020586,
+    "ast_hash": "dd3fcc13516c1ca88b3c446f2117ce34",
     "semantic_hash": ""
   },
   "packages/shared/tests/spec-format.test.ts": {
@@ -1180,7 +1180,7 @@
     "semantic_hash": ""
   },
   "packages/ng-openapi/src/lib/generators/type/type-resolver.ts": {
-    "mtime": 1783327889.8495443,
+    "mtime": 1783328453.3789885,
     "ast_hash": "a088bcde3a78401462826c9fed61f219",
     "semantic_hash": ""
   },
@@ -1195,12 +1195,12 @@
     "semantic_hash": ""
   },
   "packages/shared/src/emit/headers.emit.ts": {
-    "mtime": 1783296715.468304,
-    "ast_hash": "3560c03938104afe76f3d1b4769fb519",
+    "mtime": 1783330916.890713,
+    "ast_hash": "4fc4ee74d06862fc9486aab7a19f3e97",
     "semantic_hash": ""
   },
   "packages/shared/src/emit/index.ts": {
-    "mtime": 1783327887.4777975,
+    "mtime": 1783328453.488018,
     "ast_hash": "0e8d5deb6990633c1b82c73b60a9c745",
     "semantic_hash": ""
   },
@@ -1220,8 +1220,8 @@
     "semantic_hash": ""
   },
   "packages/shared/tests/emit.test.ts": {
-    "mtime": 1783296715.4893017,
-    "ast_hash": "31575b5b4e4c5671406eb9eda0964380",
+    "mtime": 1783331053.9162521,
+    "ast_hash": "dc65781412dc61028aae5d10a2298e14",
     "semantic_hash": ""
   },
   "docs/guide/plugin-authoring.md": {
@@ -1275,8 +1275,8 @@
     "semantic_hash": ""
   },
   "context7.json": {
-    "mtime": 1783298072.190625,
-    "ast_hash": "e7e61aaf19e09fa86d13b904e34e8d12",
+    "mtime": 1783328540.6117501,
+    "ast_hash": "df6fd33c023f84bfda4ecb67e2319840",
     "semantic_hash": ""
   },
   "packages/shared/src/config/define-config.ts": {
@@ -1355,12 +1355,12 @@
     "semantic_hash": ""
   },
   "packages/shared/src/utils/functions/class-names.ts": {
-    "mtime": 1783327889.8965304,
+    "mtime": 1783328453.4910178,
     "ast_hash": "a5137dc2a17a81493b9a4dfdf2bcdcfe",
     "semantic_hash": ""
   },
   "packages/shared/tests/class-names.test.ts": {
-    "mtime": 1783327889.8985507,
+    "mtime": 1783328453.4940474,
     "ast_hash": "434130f753b35111e1d72941c59561f6",
     "semantic_hash": ""
   },
@@ -1370,128 +1370,133 @@
     "semantic_hash": ""
   },
   "docs/api/configuration/options/naming.md": {
-    "mtime": 1783327889.8379624,
+    "mtime": 1783328453.36199,
     "ast_hash": "2da44f7e5f37bb499313d0ed04b69c2a",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/__golden__/edge-cases/naming/_manifest.txt": {
-    "mtime": 1783327889.8505292,
+    "mtime": 1783328453.3799894,
     "ast_hash": "6e441de45a15bb140a1058608f0f9494",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/__golden__/models-only/naming/_manifest.txt": {
-    "mtime": 1783327889.854545,
+    "mtime": 1783328453.3899894,
     "ast_hash": "8b9bba32ba28b4386cec0b6a71eeb6ea",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/__golden__/openapi-3.0/naming/_manifest.txt": {
-    "mtime": 1783327889.8575451,
+    "mtime": 1783328453.397988,
     "ast_hash": "061500855b6cf1fe9b5f5ca4c321fcd9",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/__golden__/openapi-3.1/naming/_manifest.txt": {
-    "mtime": 1783327889.861545,
+    "mtime": 1783328453.4109962,
     "ast_hash": "f3dd969e08a62158e87e4596afabf649",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/__golden__/swagger-2.0/naming/_manifest.txt": {
-    "mtime": 1783327889.865545,
+    "mtime": 1783328453.4195025,
     "ast_hash": "3a23760ec1c96e7336e537bf4aa6f1cd",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/tests/__golden__/edge-cases/naming/_manifest.txt": {
-    "mtime": 1783327889.8705466,
+    "mtime": 1783328453.4315026,
     "ast_hash": "3607c3e6e6ee8872d7c3259be8040235",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/tests/__golden__/models-only/naming/_manifest.txt": {
-    "mtime": 1783327889.8765292,
+    "mtime": 1783328453.444501,
     "ast_hash": "7cc6e7cc651fcd72c95f899d3d708a9a",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/_manifest.txt": {
-    "mtime": 1783327889.8795455,
+    "mtime": 1783328453.4515007,
     "ast_hash": "f3a24c3e642ccb72a04762625b6bc97c",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/tests/__golden__/openapi-3.1/naming/_manifest.txt": {
-    "mtime": 1783327889.8855464,
+    "mtime": 1783328453.4655056,
     "ast_hash": "a0d2aaca727789a4838b76f9f161e966",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/tests/__golden__/swagger-2.0/naming/_manifest.txt": {
-    "mtime": 1783327889.8895452,
+    "mtime": 1783328453.4760137,
     "ast_hash": "e716e3b3fae212f6e15bdb0419241068",
     "semantic_hash": ""
   },
   "packages/ng-openapi/src/lib/core/angular-version.ts": {
-    "mtime": 1783327887.4132962,
+    "mtime": 1783328453.3749871,
     "ast_hash": "107ef20d554d5d33a57d31771aad22ed",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/angular-version.test.ts": {
-    "mtime": 1783327887.4427786,
+    "mtime": 1783328453.4285016,
     "ast_hash": "e49e04adb8c931458ddee6ce3fe77f82",
     "semantic_hash": ""
   },
   "packages/shared/src/emit/service-decorator.emit.ts": {
-    "mtime": 1783327887.4788065,
+    "mtime": 1783328453.488018,
     "ast_hash": "15e6f784caf722288965834e290234ea",
     "semantic_hash": ""
   },
   "docs/api/configuration/options/service-decorator.md": {
-    "mtime": 1783327887.3701515,
+    "mtime": 1783328453.3629913,
     "ast_hash": "1106fc14e80c616054d794c046f53fb7",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/__golden__/edge-cases/service-decorator/_manifest.txt": {
-    "mtime": 1783327887.41825,
+    "mtime": 1783328453.383987,
     "ast_hash": "6e441de45a15bb140a1058608f0f9494",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/__golden__/models-only/service-decorator/_manifest.txt": {
-    "mtime": 1783327887.42325,
+    "mtime": 1783328453.3929877,
     "ast_hash": "8b9bba32ba28b4386cec0b6a71eeb6ea",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/__golden__/openapi-3.0/service-decorator/_manifest.txt": {
-    "mtime": 1783327887.4267745,
+    "mtime": 1783328453.403993,
     "ast_hash": "061500855b6cf1fe9b5f5ca4c321fcd9",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/__golden__/openapi-3.1/service-decorator/_manifest.txt": {
-    "mtime": 1783327887.4337783,
+    "mtime": 1783328453.4139924,
     "ast_hash": "f3dd969e08a62158e87e4596afabf649",
     "semantic_hash": ""
   },
   "packages/ng-openapi/tests/__golden__/swagger-2.0/service-decorator/_manifest.txt": {
-    "mtime": 1783327887.4387782,
+    "mtime": 1783328453.423501,
     "ast_hash": "3a23760ec1c96e7336e537bf4aa6f1cd",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/tests/__golden__/edge-cases/service-decorator/_manifest.txt": {
-    "mtime": 1783327887.4467783,
+    "mtime": 1783328453.4375007,
     "ast_hash": "3607c3e6e6ee8872d7c3259be8040235",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/tests/__golden__/models-only/service-decorator/_manifest.txt": {
-    "mtime": 1783327887.4537783,
+    "mtime": 1783328453.4485006,
     "ast_hash": "7cc6e7cc651fcd72c95f899d3d708a9a",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/_manifest.txt": {
-    "mtime": 1783327887.4577782,
+    "mtime": 1783328453.457505,
     "ast_hash": "f3a24c3e642ccb72a04762625b6bc97c",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/tests/__golden__/openapi-3.1/service-decorator/_manifest.txt": {
-    "mtime": 1783327887.4647796,
+    "mtime": 1783328453.4695055,
     "ast_hash": "a0d2aaca727789a4838b76f9f161e966",
     "semantic_hash": ""
   },
   "packages/plugins/http-resource/tests/__golden__/swagger-2.0/service-decorator/_manifest.txt": {
-    "mtime": 1783327887.4707894,
+    "mtime": 1783328453.4800189,
     "ast_hash": "e716e3b3fae212f6e15bdb0419241068",
+    "semantic_hash": ""
+  },
+  "docs/api/configuration/options/emit-accept-header.md": {
+    "mtime": 1783331223.2367933,
+    "ast_hash": "f9050b766ad35d5fcdab4a9e8390c56c",
     "semantic_hash": ""
   }
 }

--- a/packages/ng-openapi/src/lib/core/config-validation.ts
+++ b/packages/ng-openapi/src/lib/core/config-validation.ts
@@ -74,7 +74,12 @@ export function validateGeneratorConfig(config: unknown): asserts config is Gene
             );
         }
 
-        const booleanKeys = ["generateServices", "generateEnumBasedOnDescription", "useSingleRequestParameter"] as const;
+        const booleanKeys = [
+            "generateServices",
+            "generateEnumBasedOnDescription",
+            "useSingleRequestParameter",
+            "emitAcceptHeader",
+        ] as const;
         for (const key of booleanKeys) {
             if (options[key] !== undefined && typeof options[key] !== "boolean") {
                 issues.push(`\`options.${key}\` must be a boolean`);

--- a/packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts
+++ b/packages/ng-openapi/src/lib/generators/service/service-method/service-method-body.generator.ts
@@ -26,6 +26,7 @@ export class ServiceMethodBodyGenerator {
             emitHeaders({
                 optionsExpression: "options",
                 customHeaders: this.config.options.customHeaders,
+                accept: (this.config.options.emitAcceptHeader ?? true) ? operation.acceptHeader : undefined,
                 contentType: operation,
             }),
             this.generateMultipartFormData(operation),

--- a/packages/ng-openapi/tests/__golden__/edge-cases/client-name/services/noTags.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/client-name/services/noTags.service.ts.snap
@@ -37,6 +37,10 @@ export class NoTagsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/client-name/services/things.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/client-name/services/things.service.ts.snap
@@ -45,6 +45,10 @@ export class ThingsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -71,6 +75,32 @@ export class ThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        });
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json'>): Observable<UserProfile>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json'>): Observable<HttpResponse<UserProfile>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json'>): Observable<HttpEvent<UserProfile>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text'>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/date-enum/services/noTags.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/date-enum/services/noTags.service.ts.snap
@@ -37,6 +37,10 @@ export class NoTagsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/date-enum/services/things.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/date-enum/services/things.service.ts.snap
@@ -45,6 +45,10 @@ export class ThingsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -71,6 +75,32 @@ export class ThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        });
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json'>): Observable<UserProfile>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json'>): Observable<HttpResponse<UserProfile>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json'>): Observable<HttpEvent<UserProfile>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text'>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/default/services/noTags.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/default/services/noTags.service.ts.snap
@@ -37,6 +37,10 @@ export class NoTagsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/default/services/things.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/default/services/things.service.ts.snap
@@ -45,6 +45,10 @@ export class ThingsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -71,6 +75,32 @@ export class ThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        });
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json'>): Observable<UserProfile>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json'>): Observable<HttpResponse<UserProfile>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json'>): Observable<HttpEvent<UserProfile>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text'>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/naming/services/noTags.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/naming/services/noTags.service.ts.snap
@@ -37,6 +37,10 @@ export class ApiNoTagsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/naming/services/things.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/naming/services/things.service.ts.snap
@@ -45,6 +45,10 @@ export class ApiThingsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -71,6 +75,32 @@ export class ApiThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        });
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json'>): Observable<UserProfileDto>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json'>): Observable<HttpResponse<UserProfileDto>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json'>): Observable<HttpEvent<UserProfileDto>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text'>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/response-validation/services/noTags.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/response-validation/services/noTags.service.ts.snap
@@ -37,6 +37,10 @@ export class NoTagsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/response-validation/services/things.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/response-validation/services/things.service.ts.snap
@@ -45,6 +45,10 @@ export class ThingsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -71,6 +75,32 @@ export class ThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        }).pipe(map(response => options?.parse?.(response) ?? response));
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json', UserProfile>): Observable<UserProfile>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json', UserProfile>): Observable<HttpResponse<UserProfile>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json', UserProfile>): Observable<HttpEvent<UserProfile>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text', any>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/service-decorator/services/noTags.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/service-decorator/services/noTags.service.ts.snap
@@ -37,6 +37,10 @@ export class NoTagsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/service-decorator/services/things.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/service-decorator/services/things.service.ts.snap
@@ -45,6 +45,10 @@ export class ThingsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -71,6 +75,32 @@ export class ThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        });
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json'>): Observable<UserProfile>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json'>): Observable<HttpResponse<UserProfile>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json'>): Observable<HttpEvent<UserProfile>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text'>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/single-request-param/services/noTags.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/single-request-param/services/noTags.service.ts.snap
@@ -38,6 +38,10 @@ export class NoTagsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/edge-cases/single-request-param/services/things.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/edge-cases/single-request-param/services/things.service.ts.snap
@@ -46,6 +46,10 @@ export class ThingsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -72,6 +76,32 @@ export class ThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        });
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json'>): Observable<UserProfile>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json'>): Observable<HttpResponse<UserProfile>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json'>): Observable<HttpEvent<UserProfile>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text'>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/client-name/services/auth.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/client-name/services/auth.service.ts.snap
@@ -37,6 +37,10 @@ export class AuthService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/client-name/services/default.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/client-name/services/default.service.ts.snap
@@ -37,6 +37,10 @@ export class DefaultService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/client-name/services/files.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/client-name/services/files.service.ts.snap
@@ -37,6 +37,10 @@ export class FilesService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/client-name/services/orders.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/client-name/services/orders.service.ts.snap
@@ -48,6 +48,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -70,6 +74,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -98,6 +106,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -119,6 +131,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -146,6 +162,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/date-enum/services/auth.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/date-enum/services/auth.service.ts.snap
@@ -37,6 +37,10 @@ export class AuthService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/date-enum/services/default.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/date-enum/services/default.service.ts.snap
@@ -37,6 +37,10 @@ export class DefaultService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/date-enum/services/files.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/date-enum/services/files.service.ts.snap
@@ -37,6 +37,10 @@ export class FilesService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/date-enum/services/orders.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/date-enum/services/orders.service.ts.snap
@@ -48,6 +48,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -70,6 +74,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -98,6 +106,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -119,6 +131,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -146,6 +162,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/default/services/auth.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/default/services/auth.service.ts.snap
@@ -37,6 +37,10 @@ export class AuthService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/default/services/default.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/default/services/default.service.ts.snap
@@ -37,6 +37,10 @@ export class DefaultService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/default/services/files.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/default/services/files.service.ts.snap
@@ -37,6 +37,10 @@ export class FilesService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/default/services/orders.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/default/services/orders.service.ts.snap
@@ -48,6 +48,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -70,6 +74,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -98,6 +106,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -119,6 +131,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -146,6 +162,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/naming/services/auth.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/naming/services/auth.service.ts.snap
@@ -37,6 +37,10 @@ export class ApiAuthService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/naming/services/default.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/naming/services/default.service.ts.snap
@@ -37,6 +37,10 @@ export class ApiDefaultService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/naming/services/files.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/naming/services/files.service.ts.snap
@@ -37,6 +37,10 @@ export class ApiFilesService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/naming/services/orders.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/naming/services/orders.service.ts.snap
@@ -48,6 +48,10 @@ export class ApiOrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -70,6 +74,10 @@ export class ApiOrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -98,6 +106,10 @@ export class ApiOrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -119,6 +131,10 @@ export class ApiOrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -146,6 +162,10 @@ export class ApiOrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/response-validation/services/auth.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/response-validation/services/auth.service.ts.snap
@@ -37,6 +37,10 @@ export class AuthService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/response-validation/services/default.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/response-validation/services/default.service.ts.snap
@@ -37,6 +37,10 @@ export class DefaultService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/response-validation/services/files.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/response-validation/services/files.service.ts.snap
@@ -37,6 +37,10 @@ export class FilesService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/response-validation/services/orders.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/response-validation/services/orders.service.ts.snap
@@ -48,6 +48,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -70,6 +74,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -98,6 +106,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -119,6 +131,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -146,6 +162,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/service-decorator/services/auth.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/service-decorator/services/auth.service.ts.snap
@@ -37,6 +37,10 @@ export class AuthService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/service-decorator/services/default.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/service-decorator/services/default.service.ts.snap
@@ -37,6 +37,10 @@ export class DefaultService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/service-decorator/services/files.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/service-decorator/services/files.service.ts.snap
@@ -37,6 +37,10 @@ export class FilesService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/service-decorator/services/orders.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/service-decorator/services/orders.service.ts.snap
@@ -48,6 +48,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -70,6 +74,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -98,6 +106,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -119,6 +131,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -146,6 +162,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/single-request-param/services/auth.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/single-request-param/services/auth.service.ts.snap
@@ -38,6 +38,10 @@ export class AuthService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/single-request-param/services/default.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/single-request-param/services/default.service.ts.snap
@@ -37,6 +37,10 @@ export class DefaultService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/single-request-param/services/files.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/single-request-param/services/files.service.ts.snap
@@ -38,6 +38,10 @@ export class FilesService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/ng-openapi/tests/__golden__/openapi-3.0/single-request-param/services/orders.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.0/single-request-param/services/orders.service.ts.snap
@@ -49,6 +49,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -72,6 +76,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -101,6 +109,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -123,6 +135,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -151,6 +167,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.1/client-name/services/widgets.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.1/client-name/services/widgets.service.ts.snap
@@ -42,6 +42,10 @@ export class WidgetsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -64,6 +68,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -91,6 +99,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.1/date-enum/services/widgets.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.1/date-enum/services/widgets.service.ts.snap
@@ -42,6 +42,10 @@ export class WidgetsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -64,6 +68,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -91,6 +99,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.1/default/services/widgets.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.1/default/services/widgets.service.ts.snap
@@ -42,6 +42,10 @@ export class WidgetsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -64,6 +68,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -91,6 +99,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.1/naming/services/widgets.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.1/naming/services/widgets.service.ts.snap
@@ -42,6 +42,10 @@ export class ApiWidgetsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -64,6 +68,10 @@ export class ApiWidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -91,6 +99,10 @@ export class ApiWidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.1/response-validation/services/widgets.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.1/response-validation/services/widgets.service.ts.snap
@@ -42,6 +42,10 @@ export class WidgetsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -64,6 +68,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -91,6 +99,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.1/service-decorator/services/widgets.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.1/service-decorator/services/widgets.service.ts.snap
@@ -42,6 +42,10 @@ export class WidgetsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -64,6 +68,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -91,6 +99,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/ng-openapi/tests/__golden__/openapi-3.1/single-request-param/services/widgets.service.ts.snap
+++ b/packages/ng-openapi/tests/__golden__/openapi-3.1/single-request-param/services/widgets.service.ts.snap
@@ -43,6 +43,10 @@ export class WidgetsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -66,6 +70,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -94,6 +102,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts
+++ b/packages/plugins/http-resource/src/lib/http-resource-method/http-resource-method-body.generator.ts
@@ -16,21 +16,31 @@ export class HttpResourceMethodBodyGenerator {
     }
 
     generateMethodBody(operation: NormalizedOperation): string {
-        const bodyParts = [this.generateDefaultHeaders(), this.generateHttpResource(operation)];
+        const bodyParts = [this.generateDefaultHeaders(operation), this.generateHttpResource(operation)];
 
         return bodyParts.filter(Boolean).join("\n");
     }
 
     /**
      * Caller headers flow through `...requestOptions` untouched; a headers
-     * merge is only needed when the config declares default headers.
+     * merge is only needed when the config declares default headers or the
+     * operation derives an Accept header from its response content types.
      */
-    private generateDefaultHeaders(): string {
-        const customHeaders = this.config.options.customHeaders;
-        if (!customHeaders || Object.keys(customHeaders).length === 0) {
+    private generateDefaultHeaders(operation: NormalizedOperation): string {
+        const defaultHeaders = this.defaultHeaders(operation);
+        if (Object.keys(defaultHeaders).length === 0) {
             return "";
         }
-        return emitDefaultHeadersMerge("requestOptions", customHeaders);
+        return emitDefaultHeadersMerge("requestOptions", defaultHeaders);
+    }
+
+    /** Spec-derived Accept first so configured customHeaders can override it. */
+    private defaultHeaders(operation: NormalizedOperation): Record<string, string> {
+        const emitAccept = this.config.options.emitAcceptHeader ?? true;
+        return {
+            ...(emitAccept && operation.acceptHeader ? { Accept: operation.acceptHeader } : {}),
+            ...this.config.options.customHeaders,
+        };
     }
 
     private generateRequestOptions(operation: NormalizedOperation): string {
@@ -48,7 +58,7 @@ export class HttpResourceMethodBodyGenerator {
             entries.push("params");
         }
 
-        if (this.config.options.customHeaders && Object.keys(this.config.options.customHeaders).length > 0) {
+        if (Object.keys(this.defaultHeaders(operation)).length > 0) {
             entries.push("headers");
         }
 

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/custom-headers/resources/noTags.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/custom-headers/resources/noTags.resource.ts.snap
@@ -30,6 +30,9 @@ export class NoTagsResource {
         // Add default headers if not already present
         let headers = requestOptions?.headers;
         if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
             if (!headers.has('X-Api-Key')) {
                 headers = headers.set('X-Api-Key', 'demo-key');
             }
@@ -37,7 +40,7 @@ export class NoTagsResource {
                 headers = headers.set('X-Client-Version', '1.2.3');
             }
         } else {
-            headers = { 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
+            headers = { 'Accept': 'application/json', 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
         }
         return httpResource(() => {
             return {

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/custom-headers/resources/things.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/custom-headers/resources/things.resource.ts.snap
@@ -30,6 +30,9 @@ export class ThingsResource {
         // Add default headers if not already present
         let headers = requestOptions?.headers;
         if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
             if (!headers.has('X-Api-Key')) {
                 headers = headers.set('X-Api-Key', 'demo-key');
             }
@@ -37,7 +40,7 @@ export class ThingsResource {
                 headers = headers.set('X-Client-Version', '1.2.3');
             }
         } else {
-            headers = { 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
+            headers = { 'Accept': 'application/json', 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
         }
         return httpResource(() => {
             let params = new HttpParams();
@@ -54,6 +57,36 @@ export class ThingsResource {
                 method: "GET",
                 ...requestOptions,
                 params,
+                headers,
+                context: this.createContextWithClientId(requestOptions?.context)
+            }
+        }, resourceOptions);
+    }
+
+    getVendorThing(resourceOptions: HttpResourceOptions<UserProfile, unknown> & { defaultValue: NoInfer<UserProfile> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfile>;
+    getVendorThing(resourceOptions?: HttpResourceOptions<UserProfile, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfile | undefined>;
+    getVendorThing(resourceOptions?: HttpResourceOptions<UserProfile, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfile | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+            }
+            if (!headers.has('X-Api-Key')) {
+                headers = headers.set('X-Api-Key', 'demo-key');
+            }
+            if (!headers.has('X-Client-Version')) {
+                headers = headers.set('X-Client-Version', '1.2.3');
+            }
+        } else {
+            headers = { 'Accept': 'application/vnd.users+json;version=1.0', 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
+        }
+        return httpResource(() => {
+            return {
+                url: `${this.basePath}/things/vendor`,
+                method: "GET",
+                ...requestOptions,
                 headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/custom-headers/services/noTags.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/custom-headers/services/noTags.service.ts.snap
@@ -44,6 +44,10 @@ export class NoTagsService {
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/custom-headers/services/things.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/custom-headers/services/things.service.ts.snap
@@ -52,6 +52,10 @@ export class ThingsService {
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -85,6 +89,39 @@ export class ThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        });
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json'>): Observable<UserProfile>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json'>): Observable<HttpResponse<UserProfile>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json'>): Observable<HttpEvent<UserProfile>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text'>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Add default headers if not already present
+        if (!headers.has('X-Api-Key')) {
+            headers = headers.set('X-Api-Key', 'demo-key');
+        }
+        if (!headers.has('X-Client-Version')) {
+            headers = headers.set('X-Client-Version', '1.2.3');
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/default/resources/noTags.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/default/resources/noTags.resource.ts.snap
@@ -26,11 +26,22 @@ export class NoTagsResource {
     getMiscById(id: Signal<string> | string, resourceOptions: HttpResourceOptions<ApiResponse, unknown> & { defaultValue: NoInfer<ApiResponse> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<ApiResponse>;
     getMiscById(id: Signal<string> | string, resourceOptions?: HttpResourceOptions<ApiResponse, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<ApiResponse | undefined>;
     getMiscById(id: Signal<string> | string, resourceOptions?: HttpResourceOptions<ApiResponse, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<ApiResponse | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             return {
                 url: `${this.basePath}/misc/no-tags/${typeof id === 'function' ? id() : id}`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/default/resources/things.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/default/resources/things.resource.ts.snap
@@ -26,6 +26,16 @@ export class ThingsResource {
     listThings(filterName: Signal<string | undefined> | string | undefined, sortBy: Signal<string | undefined> | string | undefined, resourceOptions: HttpResourceOptions<Array<UserProfile>, unknown> & { defaultValue: NoInfer<Array<UserProfile>> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<UserProfile>>;
     listThings(filterName?: Signal<string | undefined> | string, sortBy?: Signal<string | undefined> | string, resourceOptions?: HttpResourceOptions<Array<UserProfile>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<UserProfile> | undefined>;
     listThings(filterName?: Signal<string | undefined> | string, sortBy?: Signal<string | undefined> | string, resourceOptions?: HttpResourceOptions<Array<UserProfile>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<UserProfile> | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             let params = new HttpParams();
             const filterNameValue = typeof filterName === 'function' ? filterName() : filterName;
@@ -41,6 +51,31 @@ export class ThingsResource {
                 method: "GET",
                 ...requestOptions,
                 params,
+                headers,
+                context: this.createContextWithClientId(requestOptions?.context)
+            }
+        }, resourceOptions);
+    }
+
+    getVendorThing(resourceOptions: HttpResourceOptions<UserProfile, unknown> & { defaultValue: NoInfer<UserProfile> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfile>;
+    getVendorThing(resourceOptions?: HttpResourceOptions<UserProfile, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfile | undefined>;
+    getVendorThing(resourceOptions?: HttpResourceOptions<UserProfile, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfile | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+            }
+        } else {
+            headers = { 'Accept': 'application/vnd.users+json;version=1.0', ...headers };
+        }
+        return httpResource(() => {
+            return {
+                url: `${this.basePath}/things/vendor`,
+                method: "GET",
+                ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/default/services/noTags.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/default/services/noTags.service.ts.snap
@@ -37,6 +37,10 @@ export class NoTagsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/default/services/things.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/default/services/things.service.ts.snap
@@ -45,6 +45,10 @@ export class ThingsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -71,6 +75,32 @@ export class ThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        });
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json'>): Observable<UserProfile>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json'>): Observable<HttpResponse<UserProfile>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json'>): Observable<HttpEvent<UserProfile>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text'>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/naming/resources/noTags.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/naming/resources/noTags.resource.ts.snap
@@ -26,11 +26,22 @@ export class NoTagsApiResource {
     getMiscById(id: Signal<string> | string, resourceOptions: HttpResourceOptions<ApiResponseDto, unknown> & { defaultValue: NoInfer<ApiResponseDto> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<ApiResponseDto>;
     getMiscById(id: Signal<string> | string, resourceOptions?: HttpResourceOptions<ApiResponseDto, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<ApiResponseDto | undefined>;
     getMiscById(id: Signal<string> | string, resourceOptions?: HttpResourceOptions<ApiResponseDto, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<ApiResponseDto | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             return {
                 url: `${this.basePath}/misc/no-tags/${typeof id === 'function' ? id() : id}`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/naming/resources/things.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/naming/resources/things.resource.ts.snap
@@ -26,6 +26,16 @@ export class ThingsApiResource {
     listThings(filterName: Signal<string | undefined> | string | undefined, sortBy: Signal<string | undefined> | string | undefined, resourceOptions: HttpResourceOptions<Array<UserProfileDto>, unknown> & { defaultValue: NoInfer<Array<UserProfileDto>> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<UserProfileDto>>;
     listThings(filterName?: Signal<string | undefined> | string, sortBy?: Signal<string | undefined> | string, resourceOptions?: HttpResourceOptions<Array<UserProfileDto>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<UserProfileDto> | undefined>;
     listThings(filterName?: Signal<string | undefined> | string, sortBy?: Signal<string | undefined> | string, resourceOptions?: HttpResourceOptions<Array<UserProfileDto>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<UserProfileDto> | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             let params = new HttpParams();
             const filterNameValue = typeof filterName === 'function' ? filterName() : filterName;
@@ -41,6 +51,31 @@ export class ThingsApiResource {
                 method: "GET",
                 ...requestOptions,
                 params,
+                headers,
+                context: this.createContextWithClientId(requestOptions?.context)
+            }
+        }, resourceOptions);
+    }
+
+    getVendorThing(resourceOptions: HttpResourceOptions<UserProfileDto, unknown> & { defaultValue: NoInfer<UserProfileDto> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfileDto>;
+    getVendorThing(resourceOptions?: HttpResourceOptions<UserProfileDto, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfileDto | undefined>;
+    getVendorThing(resourceOptions?: HttpResourceOptions<UserProfileDto, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfileDto | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+            }
+        } else {
+            headers = { 'Accept': 'application/vnd.users+json;version=1.0', ...headers };
+        }
+        return httpResource(() => {
+            return {
+                url: `${this.basePath}/things/vendor`,
+                method: "GET",
+                ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/naming/services/noTags.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/naming/services/noTags.service.ts.snap
@@ -37,6 +37,10 @@ export class ApiNoTagsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/naming/services/things.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/naming/services/things.service.ts.snap
@@ -45,6 +45,10 @@ export class ApiThingsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -71,6 +75,32 @@ export class ApiThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        });
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json'>): Observable<UserProfileDto>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json'>): Observable<HttpResponse<UserProfileDto>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json'>): Observable<HttpEvent<UserProfileDto>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text'>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/service-decorator/resources/noTags.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/service-decorator/resources/noTags.resource.ts.snap
@@ -26,11 +26,22 @@ export class NoTagsResource {
     getMiscById(id: Signal<string> | string, resourceOptions: HttpResourceOptions<ApiResponse, unknown> & { defaultValue: NoInfer<ApiResponse> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<ApiResponse>;
     getMiscById(id: Signal<string> | string, resourceOptions?: HttpResourceOptions<ApiResponse, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<ApiResponse | undefined>;
     getMiscById(id: Signal<string> | string, resourceOptions?: HttpResourceOptions<ApiResponse, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<ApiResponse | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             return {
                 url: `${this.basePath}/misc/no-tags/${typeof id === 'function' ? id() : id}`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/service-decorator/resources/things.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/service-decorator/resources/things.resource.ts.snap
@@ -26,6 +26,16 @@ export class ThingsResource {
     listThings(filterName: Signal<string | undefined> | string | undefined, sortBy: Signal<string | undefined> | string | undefined, resourceOptions: HttpResourceOptions<Array<UserProfile>, unknown> & { defaultValue: NoInfer<Array<UserProfile>> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<UserProfile>>;
     listThings(filterName?: Signal<string | undefined> | string, sortBy?: Signal<string | undefined> | string, resourceOptions?: HttpResourceOptions<Array<UserProfile>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<UserProfile> | undefined>;
     listThings(filterName?: Signal<string | undefined> | string, sortBy?: Signal<string | undefined> | string, resourceOptions?: HttpResourceOptions<Array<UserProfile>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<UserProfile> | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             let params = new HttpParams();
             const filterNameValue = typeof filterName === 'function' ? filterName() : filterName;
@@ -41,6 +51,31 @@ export class ThingsResource {
                 method: "GET",
                 ...requestOptions,
                 params,
+                headers,
+                context: this.createContextWithClientId(requestOptions?.context)
+            }
+        }, resourceOptions);
+    }
+
+    getVendorThing(resourceOptions: HttpResourceOptions<UserProfile, unknown> & { defaultValue: NoInfer<UserProfile> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfile>;
+    getVendorThing(resourceOptions?: HttpResourceOptions<UserProfile, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfile | undefined>;
+    getVendorThing(resourceOptions?: HttpResourceOptions<UserProfile, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<UserProfile | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+            }
+        } else {
+            headers = { 'Accept': 'application/vnd.users+json;version=1.0', ...headers };
+        }
+        return httpResource(() => {
+            return {
+                url: `${this.basePath}/things/vendor`,
+                method: "GET",
+                ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/service-decorator/services/noTags.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/service-decorator/services/noTags.service.ts.snap
@@ -37,6 +37,10 @@ export class NoTagsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/plugins/http-resource/tests/__golden__/edge-cases/service-decorator/services/things.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/edge-cases/service-decorator/services/things.service.ts.snap
@@ -45,6 +45,10 @@ export class ThingsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -71,6 +75,32 @@ export class ThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        });
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json'>): Observable<UserProfile>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json'>): Observable<HttpResponse<UserProfile>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json'>): Observable<HttpEvent<UserProfile>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text'>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/resources/default.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/resources/default.resource.ts.snap
@@ -29,6 +29,9 @@ export class DefaultResource {
         // Add default headers if not already present
         let headers = requestOptions?.headers;
         if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'text/plain');
+            }
             if (!headers.has('X-Api-Key')) {
                 headers = headers.set('X-Api-Key', 'demo-key');
             }
@@ -36,7 +39,7 @@ export class DefaultResource {
                 headers = headers.set('X-Client-Version', '1.2.3');
             }
         } else {
-            headers = { 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
+            headers = { 'Accept': 'text/plain', 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
         }
         return httpResource.text(() => {
             return {

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/resources/orders.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/resources/orders.resource.ts.snap
@@ -30,6 +30,9 @@ export class OrdersResource {
         // Add default headers if not already present
         let headers = requestOptions?.headers;
         if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
             if (!headers.has('X-Api-Key')) {
                 headers = headers.set('X-Api-Key', 'demo-key');
             }
@@ -37,7 +40,7 @@ export class OrdersResource {
                 headers = headers.set('X-Client-Version', '1.2.3');
             }
         } else {
-            headers = { 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
+            headers = { 'Accept': 'application/json', 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
         }
         return httpResource(() => {
             let params = new HttpParams();
@@ -71,6 +74,9 @@ export class OrdersResource {
         // Add default headers if not already present
         let headers = requestOptions?.headers;
         if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
             if (!headers.has('X-Api-Key')) {
                 headers = headers.set('X-Api-Key', 'demo-key');
             }
@@ -78,7 +84,7 @@ export class OrdersResource {
                 headers = headers.set('X-Client-Version', '1.2.3');
             }
         } else {
-            headers = { 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
+            headers = { 'Accept': 'application/json', 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
         }
         return httpResource(() => {
             return {
@@ -98,6 +104,9 @@ export class OrdersResource {
         // Add default headers if not already present
         let headers = requestOptions?.headers;
         if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/pdf');
+            }
             if (!headers.has('X-Api-Key')) {
                 headers = headers.set('X-Api-Key', 'demo-key');
             }
@@ -105,7 +114,7 @@ export class OrdersResource {
                 headers = headers.set('X-Client-Version', '1.2.3');
             }
         } else {
-            headers = { 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
+            headers = { 'Accept': 'application/pdf', 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
         }
         return httpResource.blob(() => {
             return {

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/services/auth.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/services/auth.service.ts.snap
@@ -44,6 +44,10 @@ export class AuthService {
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/services/default.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/services/default.service.ts.snap
@@ -44,6 +44,10 @@ export class DefaultService {
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/services/files.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/services/files.service.ts.snap
@@ -44,6 +44,10 @@ export class FilesService {
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/services/orders.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/custom-headers/services/orders.service.ts.snap
@@ -55,6 +55,10 @@ export class OrdersService {
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -84,6 +88,10 @@ export class OrdersService {
         }
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -119,6 +127,10 @@ export class OrdersService {
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -147,6 +159,10 @@ export class OrdersService {
         }
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -181,6 +197,10 @@ export class OrdersService {
         }
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/resources/default.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/resources/default.resource.ts.snap
@@ -25,11 +25,22 @@ export class DefaultResource {
     getStatus(resourceOptions: HttpResourceOptions<string, string> & { defaultValue: NoInfer<string> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<string>;
     getStatus(resourceOptions?: HttpResourceOptions<string, string>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<string | undefined>;
     getStatus(resourceOptions?: HttpResourceOptions<string, string>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<string | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'text/plain');
+            }
+        } else {
+            headers = { 'Accept': 'text/plain', ...headers };
+        }
         return httpResource.text(() => {
             return {
                 url: `${this.basePath}/status`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/resources/orders.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/resources/orders.resource.ts.snap
@@ -26,6 +26,16 @@ export class OrdersResource {
     listOrders(page: Signal<number | undefined> | number | undefined, pageSize: Signal<number | undefined> | number | undefined, status: Signal<OrderStatus | undefined> | OrderStatus | undefined, resourceOptions: HttpResourceOptions<Array<Order>, unknown> & { defaultValue: NoInfer<Array<Order>> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Order>>;
     listOrders(page?: Signal<number | undefined> | number, pageSize?: Signal<number | undefined> | number, status?: Signal<OrderStatus | undefined> | OrderStatus, resourceOptions?: HttpResourceOptions<Array<Order>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Order> | undefined>;
     listOrders(page?: Signal<number | undefined> | number, pageSize?: Signal<number | undefined> | number, status?: Signal<OrderStatus | undefined> | OrderStatus, resourceOptions?: HttpResourceOptions<Array<Order>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Order> | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             let params = new HttpParams();
             const pageValue = typeof page === 'function' ? page() : page;
@@ -45,6 +55,7 @@ export class OrdersResource {
                 method: "GET",
                 ...requestOptions,
                 params,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);
@@ -53,11 +64,22 @@ export class OrdersResource {
     getOrder(orderId: Signal<string> | string, resourceOptions: HttpResourceOptions<Order, unknown> & { defaultValue: NoInfer<Order> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Order>;
     getOrder(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Order, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Order | undefined>;
     getOrder(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Order, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Order | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             return {
                 url: `${this.basePath}/orders/${typeof orderId === 'function' ? orderId() : orderId}`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);
@@ -66,11 +88,22 @@ export class OrdersResource {
     downloadInvoice(orderId: Signal<string> | string, resourceOptions: HttpResourceOptions<Blob, Blob> & { defaultValue: NoInfer<Blob> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Blob>;
     downloadInvoice(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Blob, Blob>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Blob | undefined>;
     downloadInvoice(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Blob, Blob>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Blob | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/pdf');
+            }
+        } else {
+            headers = { 'Accept': 'application/pdf', ...headers };
+        }
         return httpResource.blob(() => {
             return {
                 url: `${this.basePath}/orders/${typeof orderId === 'function' ? orderId() : orderId}/invoice`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/services/auth.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/services/auth.service.ts.snap
@@ -37,6 +37,10 @@ export class AuthService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/services/default.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/services/default.service.ts.snap
@@ -37,6 +37,10 @@ export class DefaultService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/services/files.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/services/files.service.ts.snap
@@ -37,6 +37,10 @@ export class FilesService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/services/orders.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/default/services/orders.service.ts.snap
@@ -48,6 +48,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -70,6 +74,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -98,6 +106,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -119,6 +131,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -146,6 +162,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/resources/default.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/resources/default.resource.ts.snap
@@ -25,11 +25,22 @@ export class DefaultApiResource {
     getStatus(resourceOptions: HttpResourceOptions<string, string> & { defaultValue: NoInfer<string> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<string>;
     getStatus(resourceOptions?: HttpResourceOptions<string, string>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<string | undefined>;
     getStatus(resourceOptions?: HttpResourceOptions<string, string>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<string | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'text/plain');
+            }
+        } else {
+            headers = { 'Accept': 'text/plain', ...headers };
+        }
         return httpResource.text(() => {
             return {
                 url: `${this.basePath}/status`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/resources/orders.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/resources/orders.resource.ts.snap
@@ -26,6 +26,16 @@ export class OrdersApiResource {
     listOrders(page: Signal<number | undefined> | number | undefined, pageSize: Signal<number | undefined> | number | undefined, status: Signal<OrderStatusDto | undefined> | OrderStatusDto | undefined, resourceOptions: HttpResourceOptions<Array<OrderDto>, unknown> & { defaultValue: NoInfer<Array<OrderDto>> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<OrderDto>>;
     listOrders(page?: Signal<number | undefined> | number, pageSize?: Signal<number | undefined> | number, status?: Signal<OrderStatusDto | undefined> | OrderStatusDto, resourceOptions?: HttpResourceOptions<Array<OrderDto>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<OrderDto> | undefined>;
     listOrders(page?: Signal<number | undefined> | number, pageSize?: Signal<number | undefined> | number, status?: Signal<OrderStatusDto | undefined> | OrderStatusDto, resourceOptions?: HttpResourceOptions<Array<OrderDto>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<OrderDto> | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             let params = new HttpParams();
             const pageValue = typeof page === 'function' ? page() : page;
@@ -45,6 +55,7 @@ export class OrdersApiResource {
                 method: "GET",
                 ...requestOptions,
                 params,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);
@@ -53,11 +64,22 @@ export class OrdersApiResource {
     getOrder(orderId: Signal<string> | string, resourceOptions: HttpResourceOptions<OrderDto, unknown> & { defaultValue: NoInfer<OrderDto> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<OrderDto>;
     getOrder(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<OrderDto, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<OrderDto | undefined>;
     getOrder(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<OrderDto, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<OrderDto | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             return {
                 url: `${this.basePath}/orders/${typeof orderId === 'function' ? orderId() : orderId}`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);
@@ -66,11 +88,22 @@ export class OrdersApiResource {
     downloadInvoice(orderId: Signal<string> | string, resourceOptions: HttpResourceOptions<Blob, Blob> & { defaultValue: NoInfer<Blob> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Blob>;
     downloadInvoice(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Blob, Blob>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Blob | undefined>;
     downloadInvoice(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Blob, Blob>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Blob | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/pdf');
+            }
+        } else {
+            headers = { 'Accept': 'application/pdf', ...headers };
+        }
         return httpResource.blob(() => {
             return {
                 url: `${this.basePath}/orders/${typeof orderId === 'function' ? orderId() : orderId}/invoice`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/services/auth.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/services/auth.service.ts.snap
@@ -37,6 +37,10 @@ export class ApiAuthService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/services/default.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/services/default.service.ts.snap
@@ -37,6 +37,10 @@ export class ApiDefaultService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/services/files.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/services/files.service.ts.snap
@@ -37,6 +37,10 @@ export class ApiFilesService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/services/orders.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/naming/services/orders.service.ts.snap
@@ -48,6 +48,10 @@ export class ApiOrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -70,6 +74,10 @@ export class ApiOrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -98,6 +106,10 @@ export class ApiOrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -119,6 +131,10 @@ export class ApiOrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -146,6 +162,10 @@ export class ApiOrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/resources/default.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/resources/default.resource.ts.snap
@@ -25,11 +25,22 @@ export class DefaultResource {
     getStatus(resourceOptions: HttpResourceOptions<string, string> & { defaultValue: NoInfer<string> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<string>;
     getStatus(resourceOptions?: HttpResourceOptions<string, string>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<string | undefined>;
     getStatus(resourceOptions?: HttpResourceOptions<string, string>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<string | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'text/plain');
+            }
+        } else {
+            headers = { 'Accept': 'text/plain', ...headers };
+        }
         return httpResource.text(() => {
             return {
                 url: `${this.basePath}/status`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/resources/orders.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/resources/orders.resource.ts.snap
@@ -26,6 +26,16 @@ export class OrdersResource {
     listOrders(page: Signal<number | undefined> | number | undefined, pageSize: Signal<number | undefined> | number | undefined, status: Signal<OrderStatus | undefined> | OrderStatus | undefined, resourceOptions: HttpResourceOptions<Array<Order>, unknown> & { defaultValue: NoInfer<Array<Order>> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Order>>;
     listOrders(page?: Signal<number | undefined> | number, pageSize?: Signal<number | undefined> | number, status?: Signal<OrderStatus | undefined> | OrderStatus, resourceOptions?: HttpResourceOptions<Array<Order>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Order> | undefined>;
     listOrders(page?: Signal<number | undefined> | number, pageSize?: Signal<number | undefined> | number, status?: Signal<OrderStatus | undefined> | OrderStatus, resourceOptions?: HttpResourceOptions<Array<Order>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Order> | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             let params = new HttpParams();
             const pageValue = typeof page === 'function' ? page() : page;
@@ -45,6 +55,7 @@ export class OrdersResource {
                 method: "GET",
                 ...requestOptions,
                 params,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);
@@ -53,11 +64,22 @@ export class OrdersResource {
     getOrder(orderId: Signal<string> | string, resourceOptions: HttpResourceOptions<Order, unknown> & { defaultValue: NoInfer<Order> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Order>;
     getOrder(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Order, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Order | undefined>;
     getOrder(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Order, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Order | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             return {
                 url: `${this.basePath}/orders/${typeof orderId === 'function' ? orderId() : orderId}`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);
@@ -66,11 +88,22 @@ export class OrdersResource {
     downloadInvoice(orderId: Signal<string> | string, resourceOptions: HttpResourceOptions<Blob, Blob> & { defaultValue: NoInfer<Blob> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Blob>;
     downloadInvoice(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Blob, Blob>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Blob | undefined>;
     downloadInvoice(orderId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Blob, Blob>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Blob | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/pdf');
+            }
+        } else {
+            headers = { 'Accept': 'application/pdf', ...headers };
+        }
         return httpResource.blob(() => {
             return {
                 url: `${this.basePath}/orders/${typeof orderId === 'function' ? orderId() : orderId}/invoice`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/services/auth.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/services/auth.service.ts.snap
@@ -37,6 +37,10 @@ export class AuthService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/services/default.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/services/default.service.ts.snap
@@ -37,6 +37,10 @@ export class DefaultService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/services/files.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/services/files.service.ts.snap
@@ -37,6 +37,10 @@ export class FilesService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/services/orders.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.0/service-decorator/services/orders.service.ts.snap
@@ -48,6 +48,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -70,6 +74,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -98,6 +106,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -119,6 +131,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -146,6 +162,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.1/custom-headers/resources/widgets.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.1/custom-headers/resources/widgets.resource.ts.snap
@@ -30,6 +30,9 @@ export class WidgetsResource {
         // Add default headers if not already present
         let headers = requestOptions?.headers;
         if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
             if (!headers.has('X-Api-Key')) {
                 headers = headers.set('X-Api-Key', 'demo-key');
             }
@@ -37,7 +40,7 @@ export class WidgetsResource {
                 headers = headers.set('X-Client-Version', '1.2.3');
             }
         } else {
-            headers = { 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
+            headers = { 'Accept': 'application/json', 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
         }
         return httpResource(() => {
             let params = new HttpParams();
@@ -63,6 +66,9 @@ export class WidgetsResource {
         // Add default headers if not already present
         let headers = requestOptions?.headers;
         if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
             if (!headers.has('X-Api-Key')) {
                 headers = headers.set('X-Api-Key', 'demo-key');
             }
@@ -70,7 +76,7 @@ export class WidgetsResource {
                 headers = headers.set('X-Client-Version', '1.2.3');
             }
         } else {
-            headers = { 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
+            headers = { 'Accept': 'application/json', 'X-Api-Key': 'demo-key', 'X-Client-Version': '1.2.3', ...headers };
         }
         return httpResource(() => {
             return {

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.1/custom-headers/services/widgets.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.1/custom-headers/services/widgets.service.ts.snap
@@ -49,6 +49,10 @@ export class WidgetsService {
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -78,6 +82,10 @@ export class WidgetsService {
         }
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -112,6 +120,10 @@ export class WidgetsService {
         }
         if (!headers.has('X-Client-Version')) {
             headers = headers.set('X-Client-Version', '1.2.3');
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.1/default/resources/widgets.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.1/default/resources/widgets.resource.ts.snap
@@ -26,6 +26,16 @@ export class WidgetsResource {
     listWidgets(kind: Signal<WidgetKind | undefined> | WidgetKind | undefined, resourceOptions: HttpResourceOptions<Array<Widget>, unknown> & { defaultValue: NoInfer<Array<Widget>> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Widget>>;
     listWidgets(kind?: Signal<WidgetKind | undefined> | WidgetKind, resourceOptions?: HttpResourceOptions<Array<Widget>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Widget> | undefined>;
     listWidgets(kind?: Signal<WidgetKind | undefined> | WidgetKind, resourceOptions?: HttpResourceOptions<Array<Widget>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Widget> | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             let params = new HttpParams();
             const kindValue = typeof kind === 'function' ? kind() : kind;
@@ -37,6 +47,7 @@ export class WidgetsResource {
                 method: "GET",
                 ...requestOptions,
                 params,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);
@@ -45,11 +56,22 @@ export class WidgetsResource {
     getWidget(widgetId: Signal<string> | string, resourceOptions: HttpResourceOptions<Widget, unknown> & { defaultValue: NoInfer<Widget> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Widget>;
     getWidget(widgetId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Widget, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Widget | undefined>;
     getWidget(widgetId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Widget, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Widget | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             return {
                 url: `${this.basePath}/widgets/${typeof widgetId === 'function' ? widgetId() : widgetId}`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.1/default/services/widgets.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.1/default/services/widgets.service.ts.snap
@@ -42,6 +42,10 @@ export class WidgetsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -64,6 +68,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -91,6 +99,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.1/naming/resources/widgets.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.1/naming/resources/widgets.resource.ts.snap
@@ -26,6 +26,16 @@ export class WidgetsApiResource {
     listWidgets(kind: Signal<WidgetKindDto | undefined> | WidgetKindDto | undefined, resourceOptions: HttpResourceOptions<Array<WidgetDto>, unknown> & { defaultValue: NoInfer<Array<WidgetDto>> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<WidgetDto>>;
     listWidgets(kind?: Signal<WidgetKindDto | undefined> | WidgetKindDto, resourceOptions?: HttpResourceOptions<Array<WidgetDto>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<WidgetDto> | undefined>;
     listWidgets(kind?: Signal<WidgetKindDto | undefined> | WidgetKindDto, resourceOptions?: HttpResourceOptions<Array<WidgetDto>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<WidgetDto> | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             let params = new HttpParams();
             const kindValue = typeof kind === 'function' ? kind() : kind;
@@ -37,6 +47,7 @@ export class WidgetsApiResource {
                 method: "GET",
                 ...requestOptions,
                 params,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);
@@ -45,11 +56,22 @@ export class WidgetsApiResource {
     getWidget(widgetId: Signal<string> | string, resourceOptions: HttpResourceOptions<WidgetDto, unknown> & { defaultValue: NoInfer<WidgetDto> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<WidgetDto>;
     getWidget(widgetId: Signal<string> | string, resourceOptions?: HttpResourceOptions<WidgetDto, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<WidgetDto | undefined>;
     getWidget(widgetId: Signal<string> | string, resourceOptions?: HttpResourceOptions<WidgetDto, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<WidgetDto | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             return {
                 url: `${this.basePath}/widgets/${typeof widgetId === 'function' ? widgetId() : widgetId}`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.1/naming/services/widgets.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.1/naming/services/widgets.service.ts.snap
@@ -42,6 +42,10 @@ export class ApiWidgetsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -64,6 +68,10 @@ export class ApiWidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -91,6 +99,10 @@ export class ApiWidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.1/service-decorator/resources/widgets.resource.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.1/service-decorator/resources/widgets.resource.ts.snap
@@ -26,6 +26,16 @@ export class WidgetsResource {
     listWidgets(kind: Signal<WidgetKind | undefined> | WidgetKind | undefined, resourceOptions: HttpResourceOptions<Array<Widget>, unknown> & { defaultValue: NoInfer<Array<Widget>> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Widget>>;
     listWidgets(kind?: Signal<WidgetKind | undefined> | WidgetKind, resourceOptions?: HttpResourceOptions<Array<Widget>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Widget> | undefined>;
     listWidgets(kind?: Signal<WidgetKind | undefined> | WidgetKind, resourceOptions?: HttpResourceOptions<Array<Widget>, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Array<Widget> | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             let params = new HttpParams();
             const kindValue = typeof kind === 'function' ? kind() : kind;
@@ -37,6 +47,7 @@ export class WidgetsResource {
                 method: "GET",
                 ...requestOptions,
                 params,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);
@@ -45,11 +56,22 @@ export class WidgetsResource {
     getWidget(widgetId: Signal<string> | string, resourceOptions: HttpResourceOptions<Widget, unknown> & { defaultValue: NoInfer<Widget> }, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Widget>;
     getWidget(widgetId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Widget, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Widget | undefined>;
     getWidget(widgetId: Signal<string> | string, resourceOptions?: HttpResourceOptions<Widget, unknown>, requestOptions?: Omit<HttpResourceRequest, "method" | "url" | "params">): HttpResourceRef<Widget | undefined> {
+
+        // Add default headers if not already present
+        let headers = requestOptions?.headers;
+        if (headers instanceof HttpHeaders) {
+            if (!headers.has('Accept')) {
+                headers = headers.set('Accept', 'application/json');
+            }
+        } else {
+            headers = { 'Accept': 'application/json', ...headers };
+        }
         return httpResource(() => {
             return {
                 url: `${this.basePath}/widgets/${typeof widgetId === 'function' ? widgetId() : widgetId}`,
                 method: "GET",
                 ...requestOptions,
+                headers,
                 context: this.createContextWithClientId(requestOptions?.context)
             }
         }, resourceOptions);

--- a/packages/plugins/http-resource/tests/__golden__/openapi-3.1/service-decorator/services/widgets.service.ts.snap
+++ b/packages/plugins/http-resource/tests/__golden__/openapi-3.1/service-decorator/services/widgets.service.ts.snap
@@ -42,6 +42,10 @@ export class WidgetsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -64,6 +68,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -91,6 +99,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/plugins/zod/tests/__golden__/edge-cases/default/services/noTags.service.ts.snap
+++ b/packages/plugins/zod/tests/__golden__/edge-cases/default/services/noTags.service.ts.snap
@@ -37,6 +37,10 @@ export class NoTagsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/plugins/zod/tests/__golden__/edge-cases/default/services/things.service.ts.snap
+++ b/packages/plugins/zod/tests/__golden__/edge-cases/default/services/things.service.ts.snap
@@ -45,6 +45,10 @@ export class ThingsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -71,6 +75,32 @@ export class ThingsService {
 
         return this.httpClient.request('post', url, {
             body: null,
+            observe,
+            headers,
+            reportProgress: options?.reportProgress,
+            withCredentials: options?.withCredentials,
+            context: this.createContextWithClientId(options?.context)
+        }).pipe(map(response => options?.parse?.(response) ?? response));
+    }
+
+    getVendorThing(observe?: 'body', options?: RequestOptions<'json', UserProfile>): Observable<UserProfile>;
+    getVendorThing(observe?: 'response', options?: RequestOptions<'json', UserProfile>): Observable<HttpResponse<UserProfile>>;
+    getVendorThing(observe?: 'events', options?: RequestOptions<'json', UserProfile>): Observable<HttpEvent<UserProfile>>;
+    getVendorThing(observe?: 'body' | 'events' | 'response', options?: RequestOptions<'arraybuffer' | 'blob' | 'json' | 'text', any>): Observable<any> {
+        const url = `${this.basePath}/things/vendor`;
+
+        let headers: HttpHeaders;
+        if (options?.headers instanceof HttpHeaders) {
+            headers = options.headers;
+        } else {
+            headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
+        }
+
+        return this.httpClient.request('get', url, {
             observe,
             headers,
             reportProgress: options?.reportProgress,

--- a/packages/plugins/zod/tests/__golden__/openapi-3.0/default/services/auth.service.ts.snap
+++ b/packages/plugins/zod/tests/__golden__/openapi-3.0/default/services/auth.service.ts.snap
@@ -37,6 +37,10 @@ export class AuthService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Set Content-Type for URL-encoded form data
         if (!headers.has('Content-Type')) {
             headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');

--- a/packages/plugins/zod/tests/__golden__/openapi-3.0/default/services/default.service.ts.snap
+++ b/packages/plugins/zod/tests/__golden__/openapi-3.0/default/services/default.service.ts.snap
@@ -37,6 +37,10 @@ export class DefaultService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'text/plain');
+        }
 
         return this.httpClient.request('get', url, {
             observe,

--- a/packages/plugins/zod/tests/__golden__/openapi-3.0/default/services/files.service.ts.snap
+++ b/packages/plugins/zod/tests/__golden__/openapi-3.0/default/services/files.service.ts.snap
@@ -37,6 +37,10 @@ export class FilesService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
         // Remove Content-Type for multipart (browser will set it with boundary)
         headers = headers.delete('Content-Type');
 

--- a/packages/plugins/zod/tests/__golden__/openapi-3.0/default/services/orders.service.ts.snap
+++ b/packages/plugins/zod/tests/__golden__/openapi-3.0/default/services/orders.service.ts.snap
@@ -48,6 +48,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -70,6 +74,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -98,6 +106,10 @@ export class OrdersService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -119,6 +131,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -146,6 +162,10 @@ export class OrdersService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/pdf');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/plugins/zod/tests/__golden__/openapi-3.1/default/services/widgets.service.ts.snap
+++ b/packages/plugins/zod/tests/__golden__/openapi-3.1/default/services/widgets.service.ts.snap
@@ -42,6 +42,10 @@ export class WidgetsService {
         } else {
             headers = new HttpHeaders(options?.headers);
         }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
+        }
 
         return this.httpClient.request('get', url, {
             observe,
@@ -64,6 +68,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
         // Set Content-Type for JSON requests if not already set
         if (!headers.has('Content-Type')) {
@@ -91,6 +99,10 @@ export class WidgetsService {
             headers = options.headers;
         } else {
             headers = new HttpHeaders(options?.headers);
+        }
+        // Advertise the response content type declared in the spec
+        if (!headers.has('Accept')) {
+            headers = headers.set('Accept', 'application/json');
         }
 
         return this.httpClient.request('get', url, {

--- a/packages/shared/src/core/normalize.ts
+++ b/packages/shared/src/core/normalize.ts
@@ -2,9 +2,10 @@
 // import graph cycle-free — see swagger-parser.ts for the same rule.
 import { CONTENT_TYPES } from "../utils/content-types.constants";
 import { extractPaths } from "../utils/functions/extract-paths";
-import { getResponseTypeFromResponse } from "../utils/functions/extract-swagger-response-type";
+import { getResponseInfoFromResponse } from "../utils/functions/extract-swagger-response-type";
+import type { ResponseTypeInfo } from "../utils/functions/extract-swagger-response-type";
 import type { PathInfo, RequestBody, SwaggerDefinition, SwaggerSpec } from "../types/swagger.types";
-import type { NormalizedOperation, ResponseKind } from "../model/operation.model";
+import type { NormalizedOperation } from "../model/operation.model";
 import type { NormalizedSpec } from "../model/spec.model";
 
 type ResolveRef = (ref: string) => SwaggerDefinition | undefined;
@@ -161,6 +162,8 @@ function normalizeOperation(operation: PathInfo, resolveRef: ResolveRef): Normal
         ? resolveBodySchema(operation.requestBody, CONTENT_TYPES.FORM_URLENCODED, resolveRef)
         : undefined;
 
+    const responseInfo = determineResponseInfo(operation);
+
     return {
         ...operation,
         pathParams: operation.parameters?.filter((p) => p.in === "path") || [],
@@ -172,7 +175,8 @@ function normalizeOperation(operation: PathInfo, resolveRef: ResolveRef): Normal
         formDataFields: Object.keys(formDataSchema?.properties || {}),
         urlEncodedSchema,
         urlEncodedFields: Object.keys(urlEncodedSchema?.properties || {}),
-        responseType: determineResponseType(operation),
+        responseType: responseInfo.responseType,
+        acceptHeader: responseInfo.acceptHeader,
     };
 }
 
@@ -185,15 +189,15 @@ function resolveBodySchema(
     return schema?.$ref ? resolveRef(schema.$ref) : schema;
 }
 
-function determineResponseType(operation: PathInfo): ResponseKind {
+function determineResponseInfo(operation: PathInfo): ResponseTypeInfo {
     const successResponses = ["200", "201", "202", "204", "206"];
 
     for (const statusCode of successResponses) {
         const response = operation.responses?.[statusCode];
         if (!response) continue;
 
-        return getResponseTypeFromResponse(response);
+        return getResponseInfoFromResponse(response);
     }
 
-    return "json";
+    return { responseType: "json" };
 }

--- a/packages/shared/src/emit/headers.emit.ts
+++ b/packages/shared/src/emit/headers.emit.ts
@@ -3,6 +3,8 @@ export interface HeadersEmitOptions {
     optionsExpression: string;
     /** Default headers from GeneratorConfig, added when not already present on the request. */
     customHeaders?: Record<string, string>;
+    /** Accept value derived from the operation's response content types; omit to skip. */
+    accept?: string;
     /** Content-Type rules derived from the operation's body; omit to skip (http-resource is GET-only). */
     contentType?: {
         isMultipart: boolean;
@@ -13,11 +15,11 @@ export interface HeadersEmitOptions {
 
 /**
  * Emits the `headers` initialization block: normalize the caller-supplied
- * headers into HttpHeaders, apply configured default headers, then apply
- * Content-Type rules.
+ * headers into HttpHeaders, apply configured default headers, apply the
+ * spec-derived Accept header, then apply Content-Type rules.
  */
 export function emitHeaders(options: HeadersEmitOptions): string {
-    const { optionsExpression, customHeaders, contentType } = options;
+    const { optionsExpression, customHeaders, accept, contentType } = options;
 
     let headerCode = `
 let headers: HttpHeaders;
@@ -31,6 +33,14 @@ if (${optionsExpression}?.headers instanceof HttpHeaders) {
         headerCode += `
 // Add default headers if not already present
 ${emitDefaultHeaderGuards(customHeaders)}`;
+    }
+
+    if (accept) {
+        headerCode += `
+// Advertise the response content type declared in the spec
+if (!headers.has('Accept')) {
+  headers = headers.set('Accept', '${accept}');
+}`;
     }
 
     if (contentType?.isMultipart) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -69,6 +69,7 @@ export {
     getModelTypeName,
     getRequestBodyType,
     getResourceClassName,
+    getResponseInfoFromResponse,
     getResponseType,
     getResponseTypeFromResponse,
     getServiceClassName,
@@ -85,6 +86,7 @@ export {
     pascalCaseForEnums,
     screamingSnakeCase,
 } from "./utils";
+export type { ResponseTypeInfo } from "./utils";
 
 // Typed config-file helper (user-facing)
 export { defineConfig } from "./config";

--- a/packages/shared/src/model/operation.model.ts
+++ b/packages/shared/src/model/operation.model.ts
@@ -27,4 +27,9 @@ export interface NormalizedOperation extends PathInfo {
     urlEncodedFields: string[];
     /** derived from the first success response (200/201/202/204/206) */
     responseType: ResponseKind;
+    /**
+     * Accept header value derived from the same success response: its content
+     * types that agree with responseType (unset when none are declared).
+     */
+    acceptHeader?: string;
 }

--- a/packages/shared/src/types/config.types.ts
+++ b/packages/shared/src/types/config.types.ts
@@ -57,6 +57,11 @@ export interface GeneratorConfig {
         generateEnumBasedOnDescription?: boolean;
         /** Default headers added to every request when not already present. */
         customHeaders?: Record<string, string>;
+        /**
+         * Send an Accept header derived from each operation's response content
+         * types (caller-supplied and customHeaders values win). Default: true.
+         */
+        emitAcceptHeader?: boolean;
         /** Pin the Angular responseType per response content type. */
         responseTypeMapping?: {
             [contentType: string]: "json" | "blob" | "arraybuffer" | "text";
@@ -127,6 +132,7 @@ export interface MethodGenOptions {
             response?: boolean;
         };
         customHeaders?: Record<string, string>;
+        emitAcceptHeader?: boolean;
         customizeMethodName?: (operationId: string) => string;
         useSingleRequestParameter?: boolean;
         naming?: {

--- a/packages/shared/src/utils/functions/extract-swagger-response-type.ts
+++ b/packages/shared/src/utils/functions/extract-swagger-response-type.ts
@@ -2,6 +2,18 @@ import type { SwaggerDefinition, SwaggerResponse } from "../../types/swagger.typ
 import type { TypeMappingConfig } from "../../types/config.types";
 import { getTypeScriptType } from "../type.utils";
 
+/** Result of analyzing a response's content types once for both concerns. */
+export interface ResponseTypeInfo {
+    /** Angular `responseType` of the highest-priority content type. */
+    responseType: "json" | "blob" | "arraybuffer" | "text";
+    /**
+     * Accept header value: the declared content types whose inferred kind
+     * matches `responseType` (priority winner first, comma-joined, media type
+     * parameters preserved). Unset when the response declares no content.
+     */
+    acceptHeader?: string;
+}
+
 /**
  * Angular `responseType` for a response: inspects every content type the
  * response declares and picks the highest-priority match (JSON-like content
@@ -12,10 +24,23 @@ export function getResponseTypeFromResponse(
     response: SwaggerResponse,
     responseTypeMapping?: { [p: string]: "json" | "blob" | "arraybuffer" | "text" },
 ): "json" | "blob" | "arraybuffer" | "text" {
+    return getResponseInfoFromResponse(response, responseTypeMapping).responseType;
+}
+
+/**
+ * Same content-type analysis as getResponseTypeFromResponse, additionally
+ * deriving the Accept header value from the content types that agree with the
+ * chosen responseType — advertising a type the method cannot parse would
+ * invite a response Angular's HttpClient chokes on.
+ */
+export function getResponseInfoFromResponse(
+    response: SwaggerResponse,
+    responseTypeMapping?: { [p: string]: "json" | "blob" | "arraybuffer" | "text" },
+): ResponseTypeInfo {
     const content = response.content || {};
 
     if (Object.keys(content).length === 0) {
-        return "json"; // default for empty content
+        return { responseType: "json" }; // default for empty content
     }
 
     // Collect all possible response types with their priorities
@@ -88,7 +113,15 @@ export function getResponseTypeFromResponse(
 
     // Sort by priority (lower number = higher priority) and return the best match
     responseTypes.sort((a, b) => a.priority - b.priority);
-    return responseTypes[0]?.type || "json";
+    const responseType = responseTypes[0]?.type || "json";
+    const acceptedContentTypes = responseTypes
+        .filter((candidate) => candidate.type === responseType)
+        .map((candidate) => candidate.contentType);
+
+    return {
+        responseType,
+        acceptHeader: acceptedContentTypes.length > 0 ? acceptedContentTypes.join(", ") : undefined,
+    };
 }
 
 /**

--- a/packages/shared/src/utils/functions/index.ts
+++ b/packages/shared/src/utils/functions/index.ts
@@ -5,11 +5,13 @@ export { getModelTypeName, getResourceClassName, getServiceClassName } from "./c
 export { hasDuplicateFunctionNames } from "./duplicate-function-name";
 export { extractPaths } from "./extract-paths";
 export {
+    getResponseInfoFromResponse,
     getResponseType,
     getResponseTypeFromResponse,
     inferResponseTypeFromContentType,
     isPrimitiveType,
 } from "./extract-swagger-response-type";
+export type { ResponseTypeInfo } from "./extract-swagger-response-type";
 export { getRequestBodyType } from "./get-request-body-type";
 export { isDataTypeInterface } from "./is-data-type-interface";
 export { generateParseRequestTypeParams } from "./generate-parse-request-type-params";

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -17,6 +17,7 @@ export {
     getRequestBodyType,
     getResourceClassName,
     getServiceClassName,
+    getResponseInfoFromResponse,
     getResponseType,
     getResponseTypeFromResponse,
     hasDuplicateFunctionNames,
@@ -25,3 +26,4 @@ export {
     isPrimitiveType,
     isUrl,
 } from "./functions";
+export type { ResponseTypeInfo } from "./functions";

--- a/packages/shared/tests/emit.test.ts
+++ b/packages/shared/tests/emit.test.ts
@@ -66,6 +66,20 @@ describe("headers emission", () => {
         expect(block).toContain("headers = headers.set('X-Api-Key', 'secret');");
     });
 
+    it("advertises the spec-derived Accept value guarded by has()", () => {
+        const block = emitHeaders({
+            optionsExpression: "options",
+            accept: "application/vnd.users+json;version=1.0",
+        });
+        expect(block).toContain("if (!headers.has('Accept'))");
+        expect(block).toContain("headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');");
+    });
+
+    it("omits the Accept block when no accept value is given", () => {
+        const block = emitHeaders({ optionsExpression: "options" });
+        expect(block).not.toContain("Accept");
+    });
+
     it("applies content-type rules in priority order", () => {
         const multipart = emitHeaders({
             optionsExpression: "options",

--- a/packages/shared/tests/extract-swagger-response-type.test.ts
+++ b/packages/shared/tests/extract-swagger-response-type.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
     GeneratorConfig,
+    getResponseInfoFromResponse,
     getResponseType,
     getResponseTypeFromResponse,
     inferResponseTypeFromContentType,
@@ -136,6 +137,50 @@ describe("getResponseTypeFromResponse", () => {
                 },
             }),
         ).toBe("json");
+    });
+});
+
+describe("getResponseInfoFromResponse", () => {
+    it("derives the Accept header from the winning content type, media type parameters preserved", () => {
+        expect(
+            getResponseInfoFromResponse({
+                content: { "application/vnd.users+json;version=1.0": { schema: { type: "object" } } },
+            }),
+        ).toEqual({ responseType: "json", acceptHeader: "application/vnd.users+json;version=1.0" });
+    });
+
+    it("joins every content type that agrees with the chosen responseType, winner first", () => {
+        expect(
+            getResponseInfoFromResponse({
+                content: {
+                    "application/xml": {},
+                    "application/json": { schema: { type: "object" } },
+                    "application/hal+json": { schema: { type: "object" } },
+                },
+            }),
+        ).toEqual({ responseType: "json", acceptHeader: "application/json, application/hal+json" });
+    });
+
+    it("excludes content types the generated method could not parse", () => {
+        expect(
+            getResponseInfoFromResponse({
+                content: {
+                    "application/json": { schema: { type: "object" } },
+                    "application/octet-stream": {},
+                },
+            }),
+        ).toEqual({ responseType: "json", acceptHeader: "application/json" });
+    });
+
+    it("keeps the json content type when a primitive schema downgrades parsing to text", () => {
+        expect(
+            getResponseInfoFromResponse({ content: { "application/json": { schema: { type: "string" } } } }),
+        ).toEqual({ responseType: "text", acceptHeader: "application/json" });
+    });
+
+    it("leaves acceptHeader unset for missing or empty content", () => {
+        expect(getResponseInfoFromResponse({})).toEqual({ responseType: "json" });
+        expect(getResponseInfoFromResponse({ content: {} })).toEqual({ responseType: "json" });
     });
 });
 

--- a/packages/shared/tests/normalize.test.ts
+++ b/packages/shared/tests/normalize.test.ts
@@ -107,6 +107,15 @@ describe("normalizeSpec", () => {
         // 201 with no content → json default
         expect(normalized.operations.find((o) => o.operationId === "upload")!.responseType).toBe("json");
     });
+
+    it("derives acceptHeader from the same success response", () => {
+        expect(normalized.operations.find((o) => o.operationId === "getOrder")!.acceptHeader).toBe(
+            "application/json",
+        );
+        expect(normalized.operations.find((o) => o.operationId === "token")!.acceptHeader).toBe("application/pdf");
+        // 201 with no content → nothing to advertise
+        expect(normalized.operations.find((o) => o.operationId === "upload")!.acceptHeader).toBeUndefined();
+    });
 });
 
 describe("normalizeSchema (OpenAPI 3.1 constructs)", () => {

--- a/packages/testing/fixtures/specs/edge-cases.json
+++ b/packages/testing/fixtures/specs/edge-cases.json
@@ -42,6 +42,22 @@
                 }
             }
         },
+        "/things/vendor": {
+            "get": {
+                "tags": ["things"],
+                "operationId": "getVendorThing",
+                "responses": {
+                    "200": {
+                        "description": "vendor media type with parameters (issue #56)",
+                        "content": {
+                            "application/vnd.users+json;version=1.0": {
+                                "schema": { "$ref": "#/components/schemas/user-profile" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/misc/no-tags/{id}": {
             "get": {
                 "operationId": "getMiscById",


### PR DESCRIPTION
Closes #56

## What

Generated services and `httpResource` classes now send an `Accept` header derived from each operation's success-response content types, and the header can be disabled via a new `options.emitAcceptHeader` flag (default `true`).

```ts
// generated
if (!headers.has('Accept')) {
    headers = headers.set('Accept', 'application/vnd.users+json;version=1.0');
}
```

## Why

Angular's `HttpClient` fixes `responseType` before the request is sent, so the only way to make the server's answer match the parse mode the generated method committed to is to advertise it. Both established Angular generators (OpenAPI Generator `typescript-angular`, ng-openapi-gen) send a spec-derived Accept header; ng-openapi was the outlier, which broke content-negotiated APIs using versioned vendor media types (the reporter's case).

## How

- **IR**: `getResponseInfoFromResponse` extends the existing content-type priority analysis to also return the Accept value — all declared content types whose inferred kind agrees with the chosen `responseType`, priority winner first, comma-joined, media-type parameters preserved. The normalizer stores it as `NormalizedOperation.acceptHeader`; generators only consume the IR.
- **Emission**: `emitHeaders` gained an `accept` option guarded by `headers.has('Accept')`, so `customHeaders` and per-request options always win. The http-resource plugin merges Accept as the lowest-precedence default header and now initializes `headers` whenever either Accept or `customHeaders` exists.
- **Config**: `options.emitAcceptHeader?: boolean` (default `true`), validated, documented (new docs page + options table + sidebar).
- **No Accept** when the success response declares no content (e.g. `204`).
- **Swagger 2.0 output unchanged** — 2.0 `produces` is not consumed by the normalizer yet (pre-existing gap); Accept for 2.0 folds into that fix.

## Testing

- New unit tests: Accept derivation (vendor types, multi-type joining, binary exclusion, primitive-JSON text downgrade, empty content), guarded emission, normalizer wiring.
- New `getVendorThing` operation with `application/vnd.users+json;version=1.0` in the edge-cases fixture gives golden, end-to-end coverage of the issue's exact scenario.
- 104 golden snapshots regenerated (`vitest -u`) and confirmed stable on a second full run: **275 tests passing**.

## Deferred (follow-ups discussed in #56)

- Per-content-type method variants (`$Json`/`$Plain` à la ng-openapi-gen) for operations with genuinely mixed response kinds.
- Swagger 2.0 `produces` normalization.